### PR TITLE
change doc type string to int for hooksId

### DIFF
--- a/src/Core/Hook.php
+++ b/src/Core/Hook.php
@@ -32,7 +32,7 @@ class Hook
     protected $rawXml;
 
     /**
-     * @var string
+     * @var int
      */
     private $hookId;
 
@@ -71,7 +71,7 @@ class Hook
     }
 
     /**
-     * @return string
+     * @return int
      */
     public function getHookId()
     {


### PR DESCRIPTION
hooks id always return as int but docs set as string 


https://docs.bigbluebutton.org/dev/webhooks.html#hookscreate