### PR TITLE
Add always_accept_auth guest-policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ if ($createMeetingResponse->success()) {
 ```
 
 ##### Experimental features
-> :warning: **Not officially supported by bbb**, but possible with the current bbb-api.
+> :warning:  **Not officially supported by bbb**
 
 **Guest policy**
 Beside the guest policies ALWAYS_ACCEPT, ALWAYS_DENY, and ASK_MODERATOR there is also the option ALWAYS_ACCEPT_AUTH. [sourcecode](https://github.com/bigbluebutton/bigbluebutton/blob/41f19a2cd1bc7dae76cbd805cdc3ddfbf1e6ab18/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/GuestPolicy.java#L7)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ if ($createMeetingResponse->success()) {
 }
 ```
 
+##### Experimental features
+> :warning: ** Not officially supported by bbb**, but possible with the current bbb-api.
+
+**Guest policy**
+Beside the guest policies ALWAYS_ACCEPT, ALWAYS_DENY, and ASK_MODERATOR there is also the option ALWAYS_ACCEPT_AUTH. [sourcecode](https://github.com/bigbluebutton/bigbluebutton/blob/41f19a2cd1bc7dae76cbd805cdc3ddfbf1e6ab18/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/GuestPolicy.java#L7)
+
+ASK_MODERATOR is asking the moderator(s) to accept or decline the join of a user or guest. When using our api guest users are by default marked as 'unauthorized' users.
+
+By using the option ALWAYS_ACCEPT_AUTH all authorized users (non-guests) can directly join the meeting and the moderators approval is only required for unauthorized users, like guests.
+
+
+```php
+$createMeetingParams->setGuestPolicyAlwaysAcceptAuth();
+```
+
+
 #### Join a meeting
 ```php
 use BigBlueButton\Parameters\JoinMeetingParameters;

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ if ($createMeetingResponse->success()) {
 ```
 
 ##### Experimental features
-> :warning: ** Not officially supported by bbb**, but possible with the current bbb-api.
+> :warning: **Not officially supported by bbb**, but possible with the current bbb-api.
 
 **Guest policy**
 Beside the guest policies ALWAYS_ACCEPT, ALWAYS_DENY, and ASK_MODERATOR there is also the option ALWAYS_ACCEPT_AUTH. [sourcecode](https://github.com/bigbluebutton/bigbluebutton/blob/41f19a2cd1bc7dae76cbd805cdc3ddfbf1e6ab18/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/GuestPolicy.java#L7)

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -23,9 +23,10 @@ namespace BigBlueButton\Parameters;
  */
 class CreateMeetingParameters extends MetaParameters
 {
-    const ALWAYS_ACCEPT = 'ALWAYS_ACCEPT';
-    const ALWAYS_DENY   = 'ALWAYS_DENY';
-    const ASK_MODERATOR = 'ASK_MODERATOR';
+    const ALWAYS_ACCEPT      = 'ALWAYS_ACCEPT';
+    const ALWAYS_DENY        = 'ALWAYS_DENY';
+    const ASK_MODERATOR      = 'ASK_MODERATOR';
+    const ALWAYS_ACCEPT_AUTH = 'ALWAYS_ACCEPT_AUTH';
 
     /**
      * @var string
@@ -925,11 +926,31 @@ class CreateMeetingParameters extends MetaParameters
     }
 
     /**
+     * Ask moderator on join of non-moderators if user/guest is allowed to enter the meeting
      * @return CreateMeetingParameters
      */
     public function setGuestPolicyAskModerator()
     {
         $this->guestPolicy = self::ASK_MODERATOR;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isGuestPolicyAlwaysAcceptAuth()
+    {
+        return $this->guestPolicy === self::ALWAYS_ACCEPT_AUTH;
+    }
+
+    /**
+     * Ask moderator on join of guests is allowed to enter the meeting, user are allowed to join directly
+     * @return CreateMeetingParameters
+     */
+    public function setGuestPolicyAlwaysAcceptAuth()
+    {
+        $this->guestPolicy = self::ALWAYS_ACCEPT_AUTH;
 
         return $this;
     }


### PR DESCRIPTION
This pull request adds the not officially supported always_accept_auth guest policy and explains the usage in the readme and source code.

**Further reading**
https://github.com/bigbluebutton/bigbluebutton/search?q=ALWAYS_ACCEPT_AUTH&unscoped_q=ALWAYS_ACCEPT_AUTH
https://github.com/bigbluebutton/bigbluebutton/issues/9651
https://github.com/bigbluebutton/bigbluebutton/issues/9099
https://github.com/bigbluebutton/bigbluebutton/blob/41f19a2cd1bc7dae76cbd805cdc3ddfbf1e6ab18/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/GuestsWaiting.scala#L85
