### PR TITLE
Fix error handling

### DIFF
--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -19,7 +19,7 @@
 namespace BigBlueButton;
 
 use BigBlueButton\Core\ApiMethod;
-use BigBlueButton\Exceptions\BadResponseException;
+use BigBlueButton\Exceptions\NetworkException;
 use BigBlueButton\Parameters\CreateMeetingParameters;
 use BigBlueButton\Parameters\DeleteRecordingsParameters;
 use BigBlueButton\Parameters\EndMeetingParameters;
@@ -617,10 +617,12 @@ class BigBlueButton
         if ($data === false) {
             throw new \RuntimeException('Unhandled curl error: ' . curl_error($ch));
         }
+
         $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($httpcode < 200 || $httpcode >= 300) {
-            throw new BadResponseException('Bad response, HTTP code: ' . $httpcode);
+            throw new NetworkException('Bad response', $httpcode);
         }
+
         curl_close($ch);
 
         $cookies = file_get_contents($cookiefilepath);

--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -19,6 +19,7 @@
 namespace BigBlueButton;
 
 use BigBlueButton\Core\ApiMethod;
+use BigBlueButton\Exceptions\BadResponseException;
 use BigBlueButton\Parameters\CreateMeetingParameters;
 use BigBlueButton\Parameters\DeleteRecordingsParameters;
 use BigBlueButton\Parameters\EndMeetingParameters;
@@ -615,6 +616,10 @@ class BigBlueButton
         $data = curl_exec($ch);
         if ($data === false) {
             throw new \RuntimeException('Unhandled curl error: ' . curl_error($ch));
+        }
+        $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($httpcode < 200 || $httpcode >= 300) {
+            throw new BadResponseException('Bad response, HTTP code: ' . $httpcode);
         }
         curl_close($ch);
 

--- a/src/Exceptions/BadResponseException.php
+++ b/src/Exceptions/BadResponseException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BigBlueButton\Exceptions;
+
+class BadResponseException extends \Exception
+{
+}

--- a/src/Exceptions/BaseException.php
+++ b/src/Exceptions/BaseException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BigBlueButton\Exceptions;
+
+use Exception;
+
+class BaseException extends Exception
+{
+}

--- a/src/Exceptions/ConfigException.php
+++ b/src/Exceptions/ConfigException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BigBlueButton\Exceptions;
+
+class ConfigException extends BaseException
+{
+}

--- a/src/Exceptions/NetworkException.php
+++ b/src/Exceptions/NetworkException.php
@@ -2,6 +2,6 @@
 
 namespace BigBlueButton\Exceptions;
 
-class BadResponseException extends \Exception
+class NetworkException extends BaseException
 {
 }

--- a/src/Exceptions/ParsingException.php
+++ b/src/Exceptions/ParsingException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BigBlueButton\Exceptions;
+
+class ParsingException extends BaseException
+{
+}

--- a/src/Exceptions/RuntimeException.php
+++ b/src/Exceptions/RuntimeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BigBlueButton\Exceptions;
+
+class RuntimeException extends BaseException
+{
+}

--- a/tests/unit/BigBlueButtonTest.php
+++ b/tests/unit/BigBlueButtonTest.php
@@ -19,6 +19,7 @@
 namespace BigBlueButton;
 
 use BigBlueButton\Core\ApiMethod;
+use BigBlueButton\Exceptions\ConfigException;
 use BigBlueButton\Parameters\DeleteRecordingsParameters;
 use BigBlueButton\Parameters\GetRecordingsParameters;
 use BigBlueButton\Parameters\PublishRecordingsParameters;
@@ -42,6 +43,13 @@ class BigBlueButtonTest extends TestCase
         parent::setUp();
 
         $this->bbb = new BigBlueButton('http://localhost/');
+    }
+
+    public function testMissingUrl()
+    {
+        $this->expectException(ConfigException::class);
+
+        new BigBlueButton('');
     }
 
     /* Create Meeting */


### PR DESCRIPTION
@botris I updated your pull request a bit. What do you think?

This way people can check with `$exception instanceof BaseException` if this exception is from our api or something different.

fix #33