### PR TITLE
Fix get meetings fail scalelite

### DIFF
--- a/src/Responses/GetMeetingsResponse.php
+++ b/src/Responses/GetMeetingsResponse.php
@@ -38,8 +38,11 @@ class GetMeetingsResponse extends BaseResponse
     {
         if ($this->meetings === null) {
             $this->meetings = [];
-            foreach ($this->rawXml->meetings->children() as $meetingXml) {
-                $this->meetings[] = new Meeting($meetingXml);
+
+            if ($this->getMessageKey() != 'noMeetings') {
+                foreach ($this->rawXml->meetings->children() as $meetingXml) {
+                    $this->meetings[] = new Meeting($meetingXml);
+                }
             }
         }
 

--- a/src/Responses/GetMeetingsResponse.php
+++ b/src/Responses/GetMeetingsResponse.php
@@ -39,7 +39,7 @@ class GetMeetingsResponse extends BaseResponse
         if ($this->meetings === null) {
             $this->meetings = [];
 
-            if ($this->getMessageKey() != 'noMeetings') {
+            if (isset($this->rawXml->meetings)) {
                 foreach ($this->rawXml->meetings->children() as $meetingXml) {
                     $this->meetings[] = new Meeting($meetingXml);
                 }

--- a/tests/unit/Responses/GetMeetingsResponseTest.php
+++ b/tests/unit/Responses/GetMeetingsResponseTest.php
@@ -80,4 +80,19 @@ class GetMeetingsResponseTest extends TestCase
             'getVoiceParticipantCount', 'getVideoCount', 'getDuration']);
         $this->assertEachGetterValueIsBoolean($aMeeting, ['hasBeenForciblyEnded', 'isRunning', 'hasUserJoined']);
     }
+
+    public function testGetMeetingsNoMeetings()
+    {
+        // scalelite response no meetings
+        $xml            = simplexml_load_string('<response><returncode>SUCCESS</returncode><messageKey>noMeetings</messageKey><message>No meetings were found on this server.</message></response>');
+        $this->meetings = new GetMeetingsResponse($xml);
+        $this->assertEquals('SUCCESS', $this->meetings->getReturnCode());
+        $this->assertCount(0, $this->meetings->getMeetings());
+
+        // normal bbb response no meetings
+        $xml            = simplexml_load_string('<response><returncode>SUCCESS</returncode><meetings/><messageKey>noMeetings</messageKey><message>No meetings were found on this server.</message></response>');
+        $this->meetings = new GetMeetingsResponse($xml);
+        $this->assertEquals('SUCCESS', $this->meetings->getReturnCode());
+        $this->assertCount(0, $this->meetings->getMeetings());
+    }
 }


### PR DESCRIPTION
Fixes #61 by checking if 'getMeetings' response has 'noMeetings' 'messageKey' before extracting the meetings from the response 