### PR TITLE
Added support for symfony/dot-env while bootstrapping tests

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+# This file must exist to enable loading .env.local but is currently not used.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ composer.phar
 cghooks.lock
 
 .phpunit.result.cache
+
+# Local environment variables
+/.env.local
+/.env.*.local

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Inc.**
             * [PsrHttpClientTransport](#psrhttpclienttransport)
             * [SymfonyHttpClientTransport](#symfonyhttpclienttransport)
         * [Implementing your own transport (advanced)](#implementing-your-own-transport-advanced)
+* [Run tests of this library](#run-tests-of-this-library)
 * [Submitting bugs and feature requests](#submitting-bugs-and-feature-requests)
-
 
 ## :question: Why should I use a fork?
 To explain why you should use a fork, we have to explain why we created our own
@@ -473,8 +473,40 @@ final class CustomTransport implements TransportInterface
 Your `TranportInterface` implementation must use all values provided by the `TransportRequest` object passed (currently content type, URL and payload (body)).
 Based on the response by the backend you are using you must construct a proper `TransportResponse` object containing response body and the JSESSION cookie when passed by BBB.
 
+## Run tests of this library
+
+Before running the tests, please ensure that all development dependencies of this package are installed.
+Depending on the version of composer you possibly need to run
+
+```shell
+composer install --dev
+```
+
+To run the unit tests of this library simply type
+
+```shell
+composer test tests/unit
+```
+
+The integration requires additional setup as there are using a real BigBlueButton server.
+You need to create a `.env.local` file to configure which server to use and the proper credentials:
+
+```shell
+echo "BBB_SERVER_BASE_URL=https://bbb.example/bigbluebutton/" > env.local
+echo "BBB_SECRET=S3cr3t" >> .env.local
+```
+
+It is also possible to pass both variables as real environment variables by using e.g. `export` in your shell.
+
+To run the integration tests of this library then type
+
+```shell
+composer test tests/integration
+```
+
 ## Submitting bugs and feature requests
 
 Bugs and feature request are tracked on [GitHub](https://github.com/littleredbutton/bigbluebutton-api-php/issues)
 
 [BigBlueButton API]: https://docs.bigbluebutton.org/dev/api.html
+

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,11 @@
       "name": "Alfonso Rodríguez",
       "email": "arodriguez@teltek.es",
       "role": "Developer"
+    },
+    {
+      "name": "Felix Jacobi",
+      "email": "felix@jacobi-hamburg.net",
+      "role": "Developer"
     }
   ],
   "repositories": {
@@ -78,6 +83,7 @@
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
+    "symfony/dotenv": "^3.4|^4.0|^5.0",
     "symfony/http-client-contracts": "^1.1|^2.0",
     "symfony/http-client": "^4.4|^5.0",
     "symfony/process": "^3.4|^4.0|^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1de3546dd900f5344cfe86c783cb6f0b",
+    "content-hash": "ef5e21f14b015857564983e179661df5",
     "packages": [],
     "packages-dev": [
         {
@@ -3726,6 +3726,76 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "symfony/dotenv",
+            "version": "v5.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dotenv.git",
+                "reference": "783f12027c6b40ab0e93d6136d9f642d1d67cd6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/783f12027c6b40ab0e93d6136d9f642d1d67cd6b",
+                "reference": "783f12027c6b40ab0e93d6136d9f642d1d67cd6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1"
+            },
+            "require-dev": {
+                "symfony/process": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Dotenv\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Registers environment variables from a .env file",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/dotenv/tree/v5.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-27T10:01:46+00:00"
         },
         {
             "name": "symfony/event-dispatcher",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,9 +16,23 @@
  * You should have received a copy of the GNU Lesser General Public License along
  * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
  */
+
+use Symfony\Component\Dotenv\Dotenv;
+
 error_reporting(-1);
 date_default_timezone_set('UTC');
+
 // Include the composer autoloader
-$loader = require_once __DIR__.'/../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
+
+// Load environment
+$dotenv = new Dotenv();
+// usePutenv was not available in version 3.4 und early 4.x versions of symfony/dotenv, so make it optional here
+if (method_exists($dotenv, 'usePutenv')) {
+    $dotenv->usePutenv(true);
+}
+
+$dotenv->loadEnv(dirname(__DIR__) . '/.env');
+
 // Include custom test class
 require_once __DIR__.'/TestCase.php';

--- a/tests/unit/BigBlueButtonTest.php
+++ b/tests/unit/BigBlueButtonTest.php
@@ -49,7 +49,14 @@ class BigBlueButtonTest extends TestCase
     {
         $this->expectException(ConfigException::class);
 
-        new BigBlueButton('');
+        $previousEnvironmentValue = getenv('BBB_SERVER_BASE_URL');
+        putenv('BBB_SERVER_BASE_URL=');
+
+        try {
+            new BigBlueButton('');
+        } finally {
+            putenv('BBB_SERVER_BASE_URL=' . $previousEnvironmentValue);
+        }
     }
 
     /* Create Meeting */


### PR DESCRIPTION
This allows to persist the BBB URL and secret used for integration testing in a .env file and releases the requirement to type an `export` statement every time.

This also eases the usage of the PHPUnit runners provided by IDEs e.g. PhpStorm as it releases the requirement to add special configuration to the PHPUnit runner.