### PR TITLE
http_build_query: Use RFC 3986 instead of RFC 1738 to improve interoperability with other libraries (fixes #74)

### DIFF
--- a/src/Parameters/BaseParameters.php
+++ b/src/Parameters/BaseParameters.php
@@ -98,6 +98,6 @@ abstract class BaseParameters
      */
     public function getHTTPQuery() //: string
     {
-        return \http_build_query($this->getHTTPQueryArray());
+        return \http_build_query($this->getHTTPQueryArray(), '', '&', PHP_QUERY_RFC3986);
     }
 }

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -659,7 +659,7 @@ class CreateMeetingParameters extends MetaParameters
             $queries = $this->filterBreakoutRelatedQueries($queries);
         }
 
-        return \http_build_query($queries);
+        return \http_build_query($queries, '', '&', PHP_QUERY_RFC3986);
     }
 
     private function filterBreakoutRelatedQueries(array $queries)

--- a/src/Parameters/SetConfigXMLParameters.php
+++ b/src/Parameters/SetConfigXMLParameters.php
@@ -78,10 +78,10 @@ class SetConfigXMLParameters extends BaseParameters
     {
         $queries = $this->getHTTPQueryArray();
 
-        $queries['configXML'] = urlencode($this->rawXml->asXML());
+        $queries['configXML'] = rawurlencode($this->rawXml->asXML());
 
         \ksort($queries);
 
-        return \http_build_query($queries);
+        return \http_build_query($queries, '', '&', PHP_QUERY_RFC3986);
     }
 }

--- a/tests/unit/BigBlueButtonTest.php
+++ b/tests/unit/BigBlueButtonTest.php
@@ -65,7 +65,7 @@ class BigBlueButtonTest extends TestCase
             if (is_bool($value)) {
                 $value = $value ? 'true' : 'false';
             }
-            $this->assertStringContainsString(\urlencode($key) . '=' . urlencode($value), $url);
+            $this->assertStringContainsString(\rawurlencode($key) . '=' . \rawurlencode($value), $url);
         }
     }
 
@@ -85,7 +85,7 @@ class BigBlueButtonTest extends TestCase
             if (is_bool($value)) {
                 $value = $value ? 'true' : 'false';
             }
-            $this->assertStringContainsString(\urlencode($key) . '=' . urlencode($value), $url);
+            $this->assertStringContainsString(\rawurlencode($key) . '=' . rawurlencode($value), $url);
         }
     }
 
@@ -110,7 +110,7 @@ class BigBlueButtonTest extends TestCase
             if (is_bool($value)) {
                 $value = $value ? 'true' : 'false';
             }
-            $this->assertStringContainsString(\urlencode($key) . '=' . urlencode($value), $url);
+            $this->assertStringContainsString(\rawurlencode($key) . '=' . rawurlencode($value), $url);
         }
     }
 
@@ -135,7 +135,6 @@ class BigBlueButtonTest extends TestCase
         $url = $this->bbb->getPublishRecordingsUrl(new PublishRecordingsParameters($this->faker->sha1, true));
         $this->assertStringContainsString(ApiMethod::PUBLISH_RECORDINGS, $url);
     }
-
     public function testDeleteRecordingsUrl()
     {
         $url = $this->bbb->getDeleteRecordingsUrl(new DeleteRecordingsParameters($this->faker->sha1));
@@ -150,7 +149,7 @@ class BigBlueButtonTest extends TestCase
             if (is_bool($value)) {
                 $value = $value ? 'true' : 'false';
             }
-            $this->assertStringContainsString(\urlencode($key) . '=' . urlencode($value), $url);
+            $this->assertStringContainsString(\rawurlencode($key) . '=' . rawurlencode($value), $url);
         }
     }
 }

--- a/tests/unit/Parameters/CreateMeetingParametersTest.php
+++ b/tests/unit/Parameters/CreateMeetingParametersTest.php
@@ -91,10 +91,10 @@ class CreateMeetingParametersTest extends TestCase
 
         $params = $createBreakoutMeetingParams->getHTTPQuery();
 
-        $this->assertStringContainsString('isBreakout=' . urlencode($createBreakoutMeetingParams->isBreakout() ? 'true' : 'false'), $params);
-        $this->assertStringContainsString('parentMeetingID=' . urlencode($createBreakoutMeetingParams->getParentMeetingId()), $params);
-        $this->assertStringContainsString('sequence=' . urlencode($createBreakoutMeetingParams->getSequence()), $params);
-        $this->assertStringContainsString('freeJoin=' . urlencode($createBreakoutMeetingParams->isFreeJoin() ? 'true' : 'false'), $params);
+        $this->assertStringContainsString('isBreakout=' . rawurlencode($createBreakoutMeetingParams->isBreakout() ? 'true' : 'false'), $params);
+        $this->assertStringContainsString('parentMeetingID=' . rawurlencode($createBreakoutMeetingParams->getParentMeetingId()), $params);
+        $this->assertStringContainsString('sequence=' . rawurlencode($createBreakoutMeetingParams->getSequence()), $params);
+        $this->assertStringContainsString('freeJoin=' . rawurlencode($createBreakoutMeetingParams->isFreeJoin() ? 'true' : 'false'), $params);
     }
 
     public function testCreateBreakoutMeetingWithMissingParams()


### PR DESCRIPTION
First seen on interacting with Symfony HTTP client.