### PR TITLE
Fixed cookie extraction in CurlTransport in PHP 8 (fixes #76)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ composer.phar
 .php_cs.cache
 cghooks.lock
 
+# PHPUnit reports (for convenience when working locally)
+reports
+
+# PHPUnit result cache
 .phpunit.result.cache
 
 # Local environment variables

--- a/src/Http/Transport/Bridge/PsrHttpClient/PsrHttpClientTransport.php
+++ b/src/Http/Transport/Bridge/PsrHttpClient/PsrHttpClientTransport.php
@@ -22,7 +22,7 @@ namespace BigBlueButton\Http\Transport\Bridge\PsrHttpClient;
 
 use BigBlueButton\Exceptions\NetworkException;
 use BigBlueButton\Exceptions\RuntimeException;
-use BigBlueButton\Http\SetCookie;
+use BigBlueButton\Http\Transport\Cookie;
 use BigBlueButton\Http\Transport\TransportInterface;
 use BigBlueButton\Http\Transport\TransportRequest;
 use BigBlueButton\Http\Transport\TransportResponse;
@@ -133,23 +133,8 @@ final class PsrHttpClientTransport implements TransportInterface
             throw new NetworkException('Bad response.', $psrResponse->getStatusCode());
         }
 
-        $jsessionCookie = null;
-
-        foreach ($psrResponse->getHeader('Set-Cookie') as $headerValue) {
-            $cookie = SetCookie::fromString($headerValue);
-
-            if ($cookie->getName() === 'JSESSIONID') {
-                $value = $cookie->getValue();
-
-                if ('' === $value) {
-                    break;
-                }
-
-                $jsessionCookie = $value;
-
-                break;
-            }
-        }
+        $headerValues   = $psrResponse->getHeader('Set-Cookie');
+        $jsessionCookie = Cookie::extractJsessionId($headerValues);
 
         return new TransportResponse($psrResponse->getBody()->getContents(), $jsessionCookie);
     }

--- a/src/Http/Transport/Bridge/SymfonyHttpClient/SymfonyHttpClientTransport.php
+++ b/src/Http/Transport/Bridge/SymfonyHttpClient/SymfonyHttpClientTransport.php
@@ -22,7 +22,7 @@ namespace BigBlueButton\Http\Transport\Bridge\SymfonyHttpClient;
 
 use BigBlueButton\Exceptions\NetworkException;
 use BigBlueButton\Exceptions\RuntimeException;
-use BigBlueButton\Http\SetCookie;
+use BigBlueButton\Http\Transport\Cookie;
 use BigBlueButton\Http\Transport\TransportInterface;
 use BigBlueButton\Http\Transport\TransportRequest;
 use BigBlueButton\Http\Transport\TransportResponse;
@@ -153,19 +153,7 @@ final class SymfonyHttpClientTransport implements TransportInterface
         $responseHeaders = $symfonyResponse->getHeaders();
 
         if (isset($responseHeaders['set-cookie'])) {
-            foreach ($responseHeaders['set-cookie'] as $headerValue) {
-                $cookie = SetCookie::fromString($headerValue);
-
-                if ($cookie->getName() === 'JSESSIONID') {
-                    $value = $cookie->getValue();
-
-                    if ('' === $value) {
-                        return null;
-                    }
-
-                    return $value;
-                }
-            }
+            return Cookie::extractJsessionId($responseHeaders['set-cookie']);
         }
 
         return null;

--- a/src/Http/Transport/Cookie.php
+++ b/src/Http/Transport/Cookie.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of littleredbutton/bigbluebutton-api-php.
+ *
+ * littleredbutton/bigbluebutton-api-php is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * littleredbutton/bigbluebutton-api-php is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with littleredbutton/bigbluebutton-api-php. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace BigBlueButton\Http\Transport;
+
+use BigBlueButton\Http\SetCookie;
+
+/**
+ * Cookie extraction utils
+ *
+ * @internal
+ */
+final class Cookie
+{
+    /**
+     * @param  string[]    $headerValues
+     * @return string|null
+     */
+    public static function extractJsessionId(array $headerValues): ?string
+    {
+        foreach ($headerValues as $headerValue) {
+            $cookie = SetCookie::fromString($headerValue);
+
+            if ($cookie->getName() === 'JSESSIONID') {
+                $value = $cookie->getValue();
+
+                if ('' === $value) {
+                    return null;
+                }
+
+                return $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Http/Transport/CurlTransport.php
+++ b/src/Http/Transport/CurlTransport.php
@@ -102,17 +102,7 @@ final class CurlTransport implements TransportInterface
         }
         // @codeCoverageIgnoreEnd
 
-        // Needed to store the JSESSIONID
-        $cookieFile = @tmpfile(); // Silenced as tmpfile can throw notices like "creating file in system temporary directory".
-        // @codeCoverageIgnoreStart
-        if (false === $cookieFile) {
-            throw new RuntimeException('Could not create temporary file for cookies.');
-        }
-        // @codeCoverageIgnoreEnd
-        $cookieFilePath = stream_get_meta_data($cookieFile)['uri'];
-
         $options = self::mergeCurlOptions(
-            self::buildCookieOptions($cookieFilePath),
             self::buildUrlOptions($request),
             self::buildPostOptions($request),
             self::INTERNAL_CURL_OPTIONS,
@@ -123,12 +113,7 @@ final class CurlTransport implements TransportInterface
             curl_setopt($ch, $option, $value);
         }
 
-        $data = curl_exec($ch);
-        // @codeCoverageIgnoreStart
-        if ($data === false) {
-            throw new NetworkException('Error during curl_exec. Error: ' . curl_error($ch));
-        }
-        // @codeCoverageIgnoreEnd
+        [$headers, $data] = self::getHeadersAndContentFromCurlHandle($ch);
 
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($httpCode < 200 || $httpCode >= 300) {
@@ -137,27 +122,12 @@ final class CurlTransport implements TransportInterface
 
         curl_close($ch);
 
-        $cookies   = file_get_contents($cookieFilePath);
         $sessionId = null;
-
-        if (strpos($cookies, 'JSESSIONID') !== false) {
-            preg_match('/(?:JSESSIONID\s*)(?<JSESSIONID>.*)/', $cookies, $output);
-            $sessionId = $output['JSESSIONID'];
+        if (isset($headers['set-cookie'])) {
+            $sessionId = Cookie::extractJsessionId($headers['set-cookie']);
         }
 
         return new TransportResponse($data, $sessionId);
-    }
-
-    /**
-     * @param  string  $cookieFilePath
-     * @return mixed[]
-     */
-    private static function buildCookieOptions(string $cookieFilePath): array
-    {
-        return [
-            CURLOPT_COOKIEFILE => $cookieFilePath,
-            CURLOPT_COOKIEJAR  => $cookieFilePath,
-        ];
     }
 
     /**
@@ -169,7 +139,6 @@ final class CurlTransport implements TransportInterface
         $options = [];
 
         if ('' !== $payload = $request->getPayload()) {
-            $options[CURLOPT_HEADER]        = 0;
             $options[CURLOPT_CUSTOMREQUEST] = 'POST';
             $options[CURLOPT_POST]          = 1;
             $options[CURLOPT_POSTFIELDS]    = $payload;
@@ -221,5 +190,66 @@ final class CurlTransport implements TransportInterface
         ];
 
         return ArrayHelper::mergeRecursive(true, $headerOptions, ...$options);
+    }
+
+    /**
+     * A raw response as returned from cURL will contain the headers followed by "\r\n\r\n" and the content.
+     *
+     * @param  \CurlHandle|resource $curlHandle
+     * @return array{0:             string, 1: string[]} First key headers, second key is content
+     * @throws NetworkException
+     * @link https://stackoverflow.com/questions/10589889/returning-header-as-array-using-curl
+     */
+    private static function getHeadersAndContentFromCurlHandle($curlHandle): array
+    {
+        /** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+        // @codeCoverageIgnoreStart
+        if (\PHP_VERSION_ID >= 80000 && !$curlHandle instanceof \CurlHandle) {
+            /** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+            throw new \InvalidArgumentException(sprintf('$curlHandle must be "%s". "%s" given.', \CurlHandle::class, get_debug_type($curlHandle)));
+        } elseif (\PHP_VERSION_ID < 80000 && !is_resource($curlHandle)) {
+            throw new \InvalidArgumentException(sprintf('$curlHandle must be resource. "%s" given.', is_object($curlHandle) ? get_class($curlHandle) : gettype($curlHandle)));
+        }
+        // @codeCoverageIgnoreEnd
+
+        $headers = [];
+
+        curl_setopt($curlHandle, CURLOPT_HEADER, 1);
+        $responseContent = curl_exec($curlHandle);
+
+        // @codeCoverageIgnoreStart
+        if (false === $responseContent) {
+            throw new NetworkException('Error during curl_exec. Error: ' . curl_error($curlHandle));
+        }
+        // @codeCoverageIgnoreEnd
+
+        $headerSize    = curl_getinfo($curlHandle, CURLINFO_HEADER_SIZE);
+        $headerContent = substr($responseContent, 0, $headerSize);
+
+        // Split the string on every "double" new line.
+        $headerParts = explode("\r\n\r\n", $headerContent, 2); // only split once to mitigate scrapping content if it contains newlines with carriage return
+
+        // Loop of response headers. The "count() -1" is to avoid an empty row for the extra line break before the body of the response.
+        for ($index = 0; $index < count($headerParts) - 1; $index++) {
+            foreach (explode("\r\n", $headerParts[$index]) as $i => $line) {
+                if (0 === $i) {
+                    // HTTP code
+                    continue;
+                }
+
+                $splitHeader = explode(': ', $line, 2);
+                // @codeCoverageIgnoreStart
+                if (!isset($splitHeader[0], $splitHeader[1])) {
+                    throw new \InvalidArgumentException(sprintf('Header value "%s" is invalid. Expected format is "Header-Name: value".', $line));
+                }
+                // @codeCoverageIgnoreEnd
+
+                [$header, $value] = $splitHeader;
+                // Use lower case to have an always predictable result
+                $headers[strtolower($header)][] = $value;
+            }
+        }
+
+        return [$headers, substr($responseContent, $headerSize)];
     }
 }

--- a/src/Http/Transport/Header.php
+++ b/src/Http/Transport/Header.php
@@ -48,7 +48,7 @@ final class Header
                 }
 
                 $splitHeader = explode(': ', $header, 2);
-                if (!isset($splitHeader[0]) || !isset($splitHeader[1])) {
+                if (!isset($splitHeader[0], $splitHeader[1])) {
                     throw new \InvalidArgumentException(sprintf('Header value "%s" is invalid. Expected format is "Header-Name: value".', $header));
                 }
 

--- a/tests/integration/Http/Transport/CurlTransportTest.php
+++ b/tests/integration/Http/Transport/CurlTransportTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \BigBlueButton\Http\Transport\CurlTransport
+ * @uses \BigBlueButton\Http\Transport\Cookie
  * @uses \BigBlueButton\Http\Transport\TransportRequest
  * @uses \BigBlueButton\Http\Transport\TransportResponse
  * @uses \BigBlueButton\Util\ArrayHelper
@@ -121,10 +122,6 @@ final class CurlTransportTest extends TestCase
 
     public function testRequestWithCookie(): void
     {
-        if (\PHP_VERSION_ID >= 80000) {
-            self::markTestSkipped('Broken on PHP 8. To be fixed in https://github.com/littleredbutton/bigbluebutton-api-php/pull/78.');
-        }
-
         $request   = new TransportRequest('http://localhost:8057/cookie.php', '', 'application/xml');
         $transport = new CurlTransport();
 
@@ -158,5 +155,15 @@ final class CurlTransportTest extends TestCase
 
         $this->assertSame('FOO', $dump['input'], 'input echo is correct');
         $this->assertSame('3', $dump['vars']['HTTP_CONTENT_LENGTH'], 'Content-Length echo is correct');
+    }
+
+    public function testRequestWithDoubleNewLine(): void
+    {
+        $request   = new TransportRequest('http://localhost:8057/double-newline.php', '', 'application/xml');
+        $transport = new CurlTransport();
+
+        $response = $transport->request($request);
+
+        $this->assertSame("Foo\r\n\r\nBar\r\n", $response->getBody(), 'body is correct');
     }
 }

--- a/tests/integration/Http/Transport/Fixtures/web/double-newline.php
+++ b/tests/integration/Http/Transport/Fixtures/web/double-newline.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of littleredbutton/bigbluebutton-api-php.
+ *
+ * littleredbutton/bigbluebutton-api-php is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * littleredbutton/bigbluebutton-api-php is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with littleredbutton/bigbluebutton-api-php. If not, see <http://www.gnu.org/licenses/>.
+ */
+if ('cli-server' !== \PHP_SAPI) {
+    // safe guard against unwanted execution
+    throw new \Exception("You cannot run this script directly, it's a fixture for TestHttpServer.");
+}
+
+echo "Foo\r\n\r\n";
+echo "Bar\r\n";

--- a/tests/unit/Http/Transport/Bridge/PsrHttpClient/PsrHttpClientTransportTest.php
+++ b/tests/unit/Http/Transport/Bridge/PsrHttpClient/PsrHttpClientTransportTest.php
@@ -35,7 +35,7 @@ use Psr\Http\Message\StreamInterface;
 
 /**
  * @covers \BigBlueButton\Http\Transport\Bridge\PsrHttpClient\PsrHttpClientTransport
- * @uses \BigBlueButton\Http\SetCookie
+ * @uses \BigBlueButton\Http\Transport\Cookie
  * @uses \BigBlueButton\Http\Transport\TransportRequest
  * @uses \BigBlueButton\Http\Transport\TransportResponse
  */

--- a/tests/unit/Http/Transport/Bridge/SymfonyHttpClient/SymfonyHttpClientTransportTest.php
+++ b/tests/unit/Http/Transport/Bridge/SymfonyHttpClient/SymfonyHttpClientTransportTest.php
@@ -35,7 +35,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @covers \BigBlueButton\Http\Transport\Bridge\SymfonyHttpClient\SymfonyHttpClientTransport
- * @uses \BigBlueButton\Http\SetCookie
+ * @uses \BigBlueButton\Http\Transport\Cookie
  * @uses \BigBlueButton\Http\Transport\TransportRequest
  * @uses \BigBlueButton\Http\Transport\TransportResponse
  * @uses \BigBlueButton\Util\ArrayHelper

--- a/tests/unit/Http/Transport/CookieTest.php
+++ b/tests/unit/Http/Transport/CookieTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of littleredbutton/bigbluebutton-api-php.
+ *
+ * littleredbutton/bigbluebutton-api-php is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * littleredbutton/bigbluebutton-api-php is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with littleredbutton/bigbluebutton-api-php. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace BigBlueButton\Http\Transport;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \BigBlueButton\Http\Transport\Cookie
+ * @uses \BigBlueButton\Http\SetCookie
+ */
+final class CookieTest extends TestCase
+{
+    public function testExtractJsessionIdWithSingleCookie(): void
+    {
+        $this->assertSame('Lion', Cookie::extractJsessionId(['JSESSIONID=Lion']), 'extracted cookie is OK');
+    }
+
+    public function testExtractJsessionIdWithEmptyCookie(): void
+    {
+        $this->assertNull(Cookie::extractJsessionId(['JSESSIONID=']), 'extracted cookie is OK');
+    }
+
+    public function testExtractJsessionIdWithMultipleCookies(): void
+    {
+        $this->assertSame('Tiger', Cookie::extractJsessionId(['JSESSIONID=Tiger', 'Sheldon=Bazinga']), 'extracted cookie is OK');
+    }
+
+    public function testExtractJsessionIdWithForeignCookie(): void
+    {
+        $this->assertNull(Cookie::extractJsessionId(['Sheldon=Bazinga']), 'no cookie was extracted');
+    }
+
+    public function testExtractJsessionIdWithNoCookie(): void
+    {
+        $this->assertNull(Cookie::extractJsessionId([]), 'no cookie was extracted');
+    }
+}


### PR DESCRIPTION
It seems that the format of the cookie jar of cURL cookie jar changed and so the regular expression no longer matches correctly. Good opportunity to get rid of the temporary file approach and remove almost all environment dependencies (here: writable file system).

This is a bigger change, but luckily we have integration tests here.