### PR TITLE
Added CI workflow to test with lowest supported dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,33 @@ on:
   pull_request:
 
 jobs:
+  PHP_Lowest:
+    name: PHP wth lowest dependencies
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.2']
+        experimental: [false]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup PHP, with composer and extensions
+      uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: bcmath, ctype, fileinfo, json, mbstring, dom, ldap, pdo, tokenizer, xml, mysql, sqlite
+        coverage: xdebug
+    - name: Downgrade phpunit for php7.2
+      run: composer update phpunit/phpunit -W
+    - name: Update to lowest php dependencies
+      run: composer update --prefer-lowest
+    - name: Install php dependencies
+      run: composer install --dev --no-interaction
+    - name: Execute tests without coverage
+      run: vendor/bin/phpunit --testsuite="BigBlueButton test suite"
+   
   PHP:
     name: PHP ${{ matrix.php-versions }}
     runs-on: ubuntu-latest

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,7 +32,19 @@ if (method_exists($dotenv, 'usePutenv')) {
     $dotenv->usePutenv(true);
 }
 
-$dotenv->loadEnv(dirname(__DIR__) . '/.env');
+// loadEnv was not available in version 3.4 und early 4.x versions of symfony/dotenv, so make it optional here
+if (method_exists($dotenv, 'loadEnv')) {
+    $dotenv->loadEnv(dirname(__DIR__) . '/.env');
+} else {
+    $files = [];
+    foreach ([dirname(__DIR__) . '/.env', dirname(__DIR__) . '/.env.local'] as $file) {
+        if (file_exists($file)) {
+            $files[] = $file;
+        }
+    }
+
+    $dotenv->load(...$files);
+}
 
 // Include custom test class
 require_once __DIR__.'/TestCase.php';

--- a/tests/unit/Http/Transport/Bridge/SymfonyHttpClient/SymfonyHttpClientTransportTest.php
+++ b/tests/unit/Http/Transport/Bridge/SymfonyHttpClient/SymfonyHttpClientTransportTest.php
@@ -60,7 +60,9 @@ final class SymfonyHttpClientTransportTest extends TestCase
 
         $this->assertSame('Hi Marty!', $response->getBody(), 'body is OK');
         $this->assertSame('MartyMcFlySession', $response->getSessionId(), 'session ID is OK');
-        $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        if (method_exists($mockHttpClient, 'getRequestsCount')) {
+            $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        }
     }
 
     public function testRequestWithPayload(): void
@@ -82,7 +84,9 @@ final class SymfonyHttpClientTransportTest extends TestCase
 
         $this->assertSame('Hi Marty!', $response->getBody(), 'body is OK');
         $this->assertSame('MartyMcFlySession', $response->getSessionId(), 'session ID is OK');
-        $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        if (method_exists($mockHttpClient, 'getRequestsCount')) {
+            $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        }
     }
 
     public function testRequestWithoutCookie(): void
@@ -103,7 +107,9 @@ final class SymfonyHttpClientTransportTest extends TestCase
 
         $this->assertSame('Hi Marty!', $response->getBody(), 'body is OK');
         $this->assertNull($response->getSessionId(), 'session ID is OK');
-        $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        if (method_exists($mockHttpClient, 'getRequestsCount')) {
+            $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        }
     }
 
     public function testRequestWithEmptyCookie(): void
@@ -124,7 +130,9 @@ final class SymfonyHttpClientTransportTest extends TestCase
 
         $this->assertSame('Hi Marty!', $response->getBody(), 'body is OK');
         $this->assertNull($response->getSessionId(), 'session ID is OK');
-        $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        if (method_exists($mockHttpClient, 'getRequestsCount')) {
+            $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        }
     }
 
     public function testRequestWithDefaultHeaders(): void
@@ -152,7 +160,9 @@ final class SymfonyHttpClientTransportTest extends TestCase
 
         $this->assertSame('Hi Marty!', $response->getBody(), 'body is OK');
         $this->assertSame('MartyMcFlySession', $response->getSessionId(), 'session ID is OK');
-        $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        if (method_exists($mockHttpClient, 'getRequestsCount')) {
+            $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        }
     }
 
     public function testRequestWithDefaultOptions(): void
@@ -183,7 +193,9 @@ final class SymfonyHttpClientTransportTest extends TestCase
 
         $this->assertSame('Hi Marty!', $response->getBody(), 'body is OK');
         $this->assertSame('MartyMcFlySession', $response->getSessionId(), 'session ID is OK');
-        $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        if (method_exists($mockHttpClient, 'getRequestsCount')) {
+            $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+        }
     }
 
     public function provideBadResponseCodes(): iterable
@@ -223,7 +235,9 @@ final class SymfonyHttpClientTransportTest extends TestCase
         try {
             $transport->request($request);
         } finally {
-            $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+            if (method_exists($mockHttpClient, 'getRequestsCount')) {
+                $this->assertSame(1, $mockHttpClient->getRequestsCount(), 'one request was made');
+            }
         }
     }
 
@@ -261,7 +275,9 @@ final class SymfonyHttpClientTransportTest extends TestCase
         try {
             $transport->request($request);
         } finally {
-            $this->assertSame(0, $mockHttpClient->getRequestsCount(), 'no full request was made');
+            if (method_exists($mockHttpClient, 'getRequestsCount')) {
+                $this->assertSame(0, $mockHttpClient->getRequestsCount(), 'no full request was made');
+            }
         }
     }
 
@@ -286,7 +302,9 @@ final class SymfonyHttpClientTransportTest extends TestCase
         try {
             $transport->request($request);
         } finally {
-            $this->assertSame(0, $mockHttpClient->getRequestsCount(), 'no full request was made');
+            if (method_exists($mockHttpClient, 'getRequestsCount')) {
+                $this->assertSame(0, $mockHttpClient->getRequestsCount(), 'no full request was made');
+            }
         }
     }
 }

--- a/tests/unit/Http/Transport/HeaderTest.php
+++ b/tests/unit/Http/Transport/HeaderTest.php
@@ -62,7 +62,7 @@ final class HeaderTest extends TestCase
     public function testMergeCurlHeadersWithBadHeaders(string $badHeader): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectDeprecationMessage(sprintf('Header value "%s" is invalid. Expected format is "Header-Name: value".', $badHeader));
+        $this->expectExceptionMessage(sprintf('Header value "%s" is invalid. Expected format is "Header-Name: value".', $badHeader));
 
         Header::mergeCurlHeaders([$badHeader]);
     }
@@ -85,7 +85,7 @@ final class HeaderTest extends TestCase
     public function testMergeCurlHeadersWithNonStringHeaders($badHeader): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectDeprecationMessage(sprintf(
+        $this->expectExceptionMessage(sprintf(
             'Non-string header with type "%s" passed.',
             is_object($badHeader) ? get_class($badHeader) : gettype($badHeader)
         ));


### PR DESCRIPTION
I found a few bugs in our tests here if running with the lowest supported dependencies (`composer update --prefer-lowest`). To ensure that we are really compatible with them, this adds a CI workflow job which runs with the lowest dependencies on the lowest PHP version supported.

@sualko This job should be set as required for future PRs, I guess (same for the PHP 8.0 job). As far as I can see, I cannot do that.