### PR TITLE
JoinMeetingParameters: Fixed typo in magic method annotation

### DIFF
--- a/src/Parameters/JoinMeetingParameters.php
+++ b/src/Parameters/JoinMeetingParameters.php
@@ -44,7 +44,7 @@ namespace BigBlueButton\Parameters;
  * @method string getClientURL()
  * @method $this setClientURL(string $clientURL)
  * @method bool|null isJoinViaHtml5()
- * @method $this setJoinViaHtml(bool $joinViaHtml)
+ * @method $this setJoinViaHtml5(bool $joinViaHtml)
  * @method bool|null isGuest()
  * @method $this setGuest(bool $guest)
  */


### PR DESCRIPTION
The property is named `joinViaHtml5`, calling `setJoinViaHtml` causes an `BadMethodCallException`. I would schedule this change for 4.0.1 a ka a bug fix release.