### PR TITLE
Expose all formats of a recording

### DIFF
--- a/src/Core/ImagePreview.php
+++ b/src/Core/ImagePreview.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of littleredbutton/bigbluebutton-api-php.
+ *
+ * littleredbutton/bigbluebutton-api-php is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * littleredbutton/bigbluebutton-api-php is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with littleredbutton/bigbluebutton-api-php. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace BigBlueButton\Core;
+
+class ImagePreview
+{
+    /** @var int */
+    private $width;
+
+    /** @var int */
+    private $height;
+
+    /** @var string */
+    private $alt;
+
+    /** @var string */
+    private $url;
+
+    public function __construct(int $width, int $height, string $alt, string $url)
+    {
+        $this->width  = $width;
+        $this->height = $height;
+        $this->alt    = $alt;
+        $this->url    = $url;
+    }
+
+    public function getWidth(): int
+    {
+        return $this->width;
+    }
+
+    public function getHeight(): int
+    {
+        return $this->height;
+    }
+
+    public function getAlt(): string
+    {
+        return $this->alt;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+}

--- a/src/Core/PlaybackFormat.php
+++ b/src/Core/PlaybackFormat.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of littleredbutton/bigbluebutton-api-php.
+ *
+ * littleredbutton/bigbluebutton-api-php is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * littleredbutton/bigbluebutton-api-php is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with littleredbutton/bigbluebutton-api-php. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace BigBlueButton\Core;
+
+class PlaybackFormat
+{
+
+    /** @var string */
+    private $type;
+
+    /** @var string */
+    private $url;
+
+    /** @var int */
+    private $processingTime;
+
+    /** @var int */
+    private $length;
+
+    /** @var array */
+    private $imagePreviews;
+
+    /** @var \SimpleXMLElement */
+    private $imagePreviewsRaw;
+
+    public function __construct(\SimpleXMLElement $xml)
+    {
+        $this->type               = $xml->type->__toString();
+        $this->url                = $xml->url->__toString();
+        $this->processingTime     = (int) $xml->processingTime->__toString();
+        $this->length             = (int) $xml->length->__toString();
+
+        $this->imagePreviewsRaw   = $xml->preview->images;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getProcessingTime(): int
+    {
+        return $this->processingTime;
+    }
+
+    public function getLength(): int
+    {
+        return $this->length;
+    }
+
+    public function hasImagePreviews(): bool
+    {
+        return !!$this->imagePreviewsRaw;
+    }
+
+    public function getImagePreviews(): array
+    {
+        if ($this->imagePreviews !== null) {
+            return $this->imagePreviews;
+        }
+
+        $this->imagePreviews = [];
+        if ($this->imagePreviewsRaw) {
+            foreach ($this->imagePreviewsRaw->children() as $image) {
+                $attributes = $image->attributes();
+
+                $this->imagePreviews[] = [
+                    'width'  => (int) $attributes->width->__toString(),
+                    'height' => (int) $attributes->height->__toString(),
+                    'alt'    => $attributes->alt->__toString(),
+                    'url'    => $image->__toString(),
+                ];
+            }
+        }
+
+        return $this->imagePreviews;
+    }
+}

--- a/src/Core/PlaybackFormat.php
+++ b/src/Core/PlaybackFormat.php
@@ -76,6 +76,10 @@ class PlaybackFormat
         return !!$this->imagePreviewsRaw;
     }
 
+    /**
+     *
+     * @return array<int, array{width: int, height: int, alt: string, url: string}>
+     */
     public function getImagePreviews(): array
     {
         if ($this->imagePreviews !== null) {

--- a/src/Core/PlaybackFormat.php
+++ b/src/Core/PlaybackFormat.php
@@ -35,7 +35,7 @@ class PlaybackFormat
     /** @var int */
     private $length;
 
-    /** @var array */
+    /** @var ImagePreview[] */
     private $imagePreviews;
 
     /** @var \SimpleXMLElement */
@@ -78,7 +78,7 @@ class PlaybackFormat
 
     /**
      *
-     * @return array<int, array{width: int, height: int, alt: string, url: string}>
+     * @return ImagePreview[]
      */
     public function getImagePreviews(): array
     {
@@ -91,12 +91,12 @@ class PlaybackFormat
             foreach ($this->imagePreviewsRaw->children() as $image) {
                 $attributes = $image->attributes();
 
-                $this->imagePreviews[] = [
-                    'width'  => (int) $attributes->width->__toString(),
-                    'height' => (int) $attributes->height->__toString(),
-                    'alt'    => $attributes->alt->__toString(),
-                    'url'    => $image->__toString(),
-                ];
+                $this->imagePreviews[] = new ImagePreview(
+                    (int) $attributes->width->__toString(),
+                    (int) $attributes->height->__toString(),
+                    $attributes->alt->__toString(),
+                    $image->__toString()
+                );
             }
         }
 

--- a/src/Core/Record.php
+++ b/src/Core/Record.php
@@ -128,6 +128,7 @@ class Record
     }
 
     /**
+     * @deprecated since 4.2. Use getPlaybackFormats() instead.
      * @return string
      */
     public function getPlaybackType()
@@ -136,6 +137,7 @@ class Record
     }
 
     /**
+     * @deprecated since 4.2. Use getPlaybackFormats() instead.
      * @return string
      */
     public function getPlaybackUrl()
@@ -144,6 +146,7 @@ class Record
     }
 
     /**
+     * @deprecated since 4.2. Use getPlaybackFormats() instead.
      * @return string
      */
     public function getPlaybackLength()

--- a/src/Core/Record.php
+++ b/src/Core/Record.php
@@ -35,7 +35,10 @@ class Record
     private $playbackType;
     private $playbackUrl;
     private $playbackLength;
-    private $metas;
+    private $metas = [];
+
+    /** @var PlaybackFormat[] */
+    private $playbackFormats = [];
 
     public function __construct(\SimpleXMLElement $xml)
     {
@@ -50,6 +53,10 @@ class Record
         $this->playbackType       = $xml->playback->format->type->__toString();
         $this->playbackUrl        = $xml->playback->format->url->__toString();
         $this->playbackLength     = (int) $xml->playback->format->length->__toString();
+
+        foreach ($xml->playback->children() as $format) {
+            $this->playbackFormats[] = new PlaybackFormat($format);
+        }
 
         foreach ($xml->metadata->children() as $meta) {
             $this->metas[$meta->getName()] = $meta->__toString();
@@ -150,5 +157,13 @@ class Record
     public function getMetas()
     {
         return $this->metas;
+    }
+
+    /**
+     * @return PlaybackFormat[]
+     */
+    public function getPlaybackFormats(): array
+    {
+        return $this->playbackFormats;
     }
 }

--- a/tests/fixtures/get_recordings.xml
+++ b/tests/fixtures/get_recordings.xml
@@ -163,5 +163,44 @@
                 </format>
             </playback>
         </recording>
+        <recording>
+            <recordID>ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</recordID>
+            <meetingID>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingID>
+            <internalMeetingID>ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</internalMeetingID>
+            <name>Fred's Room</name>
+            <isBreakout>false</isBreakout>
+            <published>true</published>
+            <state>published</state>
+            <startTime>1530718721124</startTime>
+            <endTime>1530718810456</endTime>
+            <participants>3</participants>
+            <metadata>
+                <isBreakout>false</isBreakout>
+                <meetingName>Fred's Room</meetingName>
+                <gl-listed>false</gl-listed>
+                <meetingId>c637ba21adcd0191f48f5c4bf23fab0f96ed5c18</meetingId>
+            </metadata>
+            <playback>
+                <format>
+                    <type>podcast</type>
+                    <url>https://demo.bigbluebutton.org/podcast/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/audio.ogg</url>
+                    <processingTime>0</processingTime>
+                    <length>0</length>
+                </format>
+                <format>
+                    <type>presentation</type>
+                    <url>https://demo.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124</url>
+                    <processingTime>7177</processingTime>
+                    <length>0</length>
+                    <preview>
+                        <images>
+                            <image alt="Welcome to" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-1.png</image>
+                            <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-2.png</image>
+                            <image alt="(this slide left blank for use as a whiteboard)" height="136" width="176">https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-3.png</image>
+                        </images>
+                    </preview>
+                </format>
+            </playback>
+        </recording>
     </recordings>
 </response>

--- a/tests/unit/Responses/GetRecordingsResponseTest.php
+++ b/tests/unit/Responses/GetRecordingsResponseTest.php
@@ -83,7 +83,7 @@ class GetRecordingsResponseTest extends TestCase
         $this->assertEachGetterValueIsDouble($aRecord, ['getStartTime', 'getEndTime']);
     }
 
-    public function testMultiplePlaybackFormats()
+    public function testMultiplePlaybackFormats(): void
     {
         $record  = $this->records->getRecords()[6];
         $formats = $record->getPlaybackFormats();

--- a/tests/unit/Responses/GetRecordingsResponseTest.php
+++ b/tests/unit/Responses/GetRecordingsResponseTest.php
@@ -101,7 +101,7 @@ class GetRecordingsResponseTest extends TestCase
         $this->assertEquals(0, $formats[1]->getLength());
     }
 
-    public function testImagePreviews()
+    public function testImagePreviews(): void
     {
         $record  = $this->records->getRecords()[6];
         $formats = $record->getPlaybackFormats();

--- a/tests/unit/Responses/GetRecordingsResponseTest.php
+++ b/tests/unit/Responses/GetRecordingsResponseTest.php
@@ -41,7 +41,7 @@ class GetRecordingsResponseTest extends TestCase
     {
         $this->assertEquals('SUCCESS', $this->records->getReturnCode());
 
-        $this->assertCount(6, $this->records->getRecords());
+        $this->assertCount(7, $this->records->getRecords());
 
         $aRecord = $this->records->getRecords()[4];
 
@@ -56,6 +56,8 @@ class GetRecordingsResponseTest extends TestCase
         $this->assertEquals('http://test-install.blindsidenetworks.com/playback/presentation/0.9.0/playback.html?meetingId=f71d810b6e90a4a34ae02b8c7143e8733178578e-1462980100026', $aRecord->getPlaybackUrl());
         $this->assertEquals(86, $aRecord->getPlaybackLength());
         $this->assertEquals(9, sizeof($aRecord->getMetas()));
+
+        $this->assertEquals($aRecord->getPlaybackUrl(), $aRecord->getPlaybackFormats()[0]->getUrl(), 'The default plackback is the first playback child');
     }
 
     public function testRecordMetadataContent()
@@ -79,5 +81,38 @@ class GetRecordingsResponseTest extends TestCase
         $this->assertEachGetterValueIsBoolean($aRecord, ['isPublished']);
 
         $this->assertEachGetterValueIsDouble($aRecord, ['getStartTime', 'getEndTime']);
+    }
+
+    public function testMultiplePlaybackFormats()
+    {
+        $record  = $this->records->getRecords()[6];
+        $formats = $record->getPlaybackFormats();
+
+        $this->assertCount(2, $formats);
+
+        $this->assertEquals('podcast', $formats[0]->getType());
+        $this->assertEquals('https://demo.bigbluebutton.org/podcast/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/audio.ogg', $formats[0]->getUrl());
+        $this->assertEquals(0, $formats[0]->getProcessingTime());
+        $this->assertEquals(0, $formats[0]->getLength());
+
+        $this->assertEquals('presentation', $formats[1]->getType());
+        $this->assertEquals('https://demo.bigbluebutton.org/playback/presentation/2.0/playback.html?meetingId=ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124', $formats[1]->getUrl());
+        $this->assertEquals(7177, $formats[1]->getProcessingTime());
+        $this->assertEquals(0, $formats[1]->getLength());
+    }
+
+    public function testImagePreviews()
+    {
+        $record  = $this->records->getRecords()[6];
+        $formats = $record->getPlaybackFormats();
+
+        $this->assertTrue($formats[1]->hasImagePreviews());
+
+        $previews = $formats[1]->getImagePreviews();
+
+        $this->assertCount(3, $previews);
+
+        $this->assertEquals('Welcome to', $previews[0]['alt']);
+        $this->assertEquals('https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-1.png', $previews[0]['url']);
     }
 }

--- a/tests/unit/Responses/GetRecordingsResponseTest.php
+++ b/tests/unit/Responses/GetRecordingsResponseTest.php
@@ -112,7 +112,7 @@ class GetRecordingsResponseTest extends TestCase
 
         $this->assertCount(3, $previews);
 
-        $this->assertEquals('Welcome to', $previews[0]['alt']);
-        $this->assertEquals('https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-1.png', $previews[0]['url']);
+        $this->assertEquals('Welcome to', $previews[0]->getAlt());
+        $this->assertEquals('https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-1.png', $previews[0]->getUrl());
     }
 }


### PR DESCRIPTION
This pr provides a way to access all available playback formats of a recording. To not break anything, I keep the existing API as a shortcut to quickly access the first format. Does someone have an idea how this could be documented? Is it enough to write it into the method description?

Another thing is that all previews are converted to an array which is maybe not the most elegant solution. What do you think? Should this also wrapped into a class?

fix #66 