### PR TITLE
set as protected instead of private so i can used in my package for overwrite object 

### DIFF
--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -96,7 +96,7 @@ class BigBlueButton
     /**
      * @var TransportInterface
      */
-    private $transport;
+    protected $transport;
 
     /**
      * @param  string|null             $baseUrl   (optional) If not given, it will be retrieved from the environment.


### PR DESCRIPTION
set as protected instead of private so i can used in my package for overwrite object 