### PR TITLE
Deprecated joinViaHtml5

### DIFF
--- a/src/Parameters/JoinMeetingParameters.php
+++ b/src/Parameters/JoinMeetingParameters.php
@@ -232,7 +232,7 @@ class JoinMeetingParameters extends UserDataParameters
     public function setJoinViaHtml5(bool $joinViaHtml5): self
     {
         @trigger_error(
-            sprintf('Using "%s" is deprecated since version 4.3 and will be removed in version 5.0. The API parameter was removed from BigBlueButton and has no effect anymore.', __METHOD__),
+            sprintf('Using "%s()" is deprecated since version 4.3 and will be removed in version 5.0. The API parameter was removed from BigBlueButton and has no effect anymore.', __METHOD__),
             E_USER_DEPRECATED
         );
 
@@ -247,7 +247,7 @@ class JoinMeetingParameters extends UserDataParameters
     public function isJoinViaHtml5(): bool
     {
         @trigger_error(
-            sprintf('Using "%s" is deprecated since version 4.3 and will be removed in version 5.0. The API parameter was removed from BigBlueButton and has no effect anymore.', __METHOD__),
+            sprintf('Using "%s()" is deprecated since version 4.3 and will be removed in version 5.0. The API parameter was removed from BigBlueButton and has no effect anymore.', __METHOD__),
             E_USER_DEPRECATED
         );
 

--- a/src/Parameters/JoinMeetingParameters.php
+++ b/src/Parameters/JoinMeetingParameters.php
@@ -43,8 +43,6 @@ namespace BigBlueButton\Parameters;
  * @method $this setRedirect(bool $redirect)
  * @method string getClientURL()
  * @method $this setClientURL(string $clientURL)
- * @method bool|null isJoinViaHtml5()
- * @method $this setJoinViaHtml5(bool $joinViaHtml)
  * @method bool|null isGuest()
  * @method $this setGuest(bool $guest)
  * @method string getRole()
@@ -224,5 +222,35 @@ class JoinMeetingParameters extends UserDataParameters
         $this->userID = $userID;
 
         return $this;
+    }
+
+    /**
+     * @deprecated since version 4.3 and will be removed in version 5.0. The API parameter was removed from BigBlueButton and has no effect anymore.
+     *
+     * @return $this
+     */
+    public function setJoinViaHtml5(bool $joinViaHtml5): self
+    {
+        @trigger_error(
+            sprintf('Using "%s" is deprecated since version 4.3 and will be removed in version 5.0. The API parameter was removed from BigBlueButton and has no effect anymore.', __METHOD__),
+            E_USER_DEPRECATED
+        );
+
+        $this->joinViaHtml5 = $joinViaHtml5;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated since version 4.3 and will be removed in version 5.0. The API parameter was removed from BigBlueButton and has no effect anymore.
+     */
+    public function isJoinViaHtml5(): bool
+    {
+        @trigger_error(
+            sprintf('Using "%s" is deprecated since version 4.3 and will be removed in version 5.0. The API parameter was removed from BigBlueButton and has no effect anymore.', __METHOD__),
+            E_USER_DEPRECATED
+        );
+
+        return $this->joinViaHtml5;
     }
 }

--- a/tests/unit/Parameters/BaseParametersTest.php
+++ b/tests/unit/Parameters/BaseParametersTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of littleredbutton/bigbluebutton-api-php.
+ *
+ * littleredbutton/bigbluebutton-api-php is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * littleredbutton/bigbluebutton-api-php is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with littleredbutton/bigbluebutton-api-php. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace BigBlueButton\Parameters;
+
+use PHPUnit\Framework\TestCase;
+
+final class BaseParametersTest extends TestCase
+{
+    public function testBooleanGetterWithNonBoolean(): void
+    {
+        $params = new TestParameters();
+
+        $this->expectException(\BadFunctionCallException::class);
+        $this->expectExceptionMessage('notABool is not a boolean property');
+
+        $params->isNotABool();
+    }
+
+    public function testGetterWithInvalid(): void
+    {
+        $params = new TestParameters();
+
+        $this->expectException(\BadFunctionCallException::class);
+        $this->expectExceptionMessage('invalid is not a valid property');
+
+        $params->getInvalid();
+    }
+
+    public function testSetterWithInvalid(): void
+    {
+        $params = new TestParameters();
+
+        $this->expectException(\BadFunctionCallException::class);
+        $this->expectExceptionMessage('invalid is not a valid property');
+
+        $params->setInvalid('foobar');
+    }
+}
+
+/**
+ * @internal
+ *
+ * @method isNotABool()
+ * @method getInvalid()
+ * @method setInvalid(string $invalid)
+ */
+final class TestParameters extends BaseParameters
+{
+    protected $notABool = 'string';
+}


### PR DESCRIPTION
fix  #124

There  is no standardized way to deprecate `@method` virtual methods. Therefore, only a runtime deprecation can be triggered :/ .