### PR TITLE
Make classes final

### DIFF
--- a/src/Core/ApiMethod.php
+++ b/src/Core/ApiMethod.php
@@ -18,10 +18,7 @@
  */
 namespace BigBlueButton\Core;
 
-/**
- * @final since 4.0.
- */
-class ApiMethod
+final class ApiMethod
 {
     public const CREATE                    = 'create';
     public const JOIN                      = 'join';

--- a/src/Exceptions/ConfigException.php
+++ b/src/Exceptions/ConfigException.php
@@ -20,9 +20,6 @@ declare(strict_types=1);
  */
 namespace BigBlueButton\Exceptions;
 
-/**
- * @final since 4.0.
- */
-class ConfigException extends BaseException
+final class ConfigException extends BaseException
 {
 }

--- a/src/Exceptions/NetworkException.php
+++ b/src/Exceptions/NetworkException.php
@@ -20,9 +20,6 @@ declare(strict_types=1);
  */
 namespace BigBlueButton\Exceptions;
 
-/**
- * @final since 4.0.
- */
-class NetworkException extends BaseException
+final class NetworkException extends BaseException
 {
 }

--- a/src/Exceptions/ParsingException.php
+++ b/src/Exceptions/ParsingException.php
@@ -20,9 +20,6 @@ declare(strict_types=1);
  */
 namespace BigBlueButton\Exceptions;
 
-/**
- * @final since 4.0.
- */
-class ParsingException extends BaseException
+final class ParsingException extends BaseException
 {
 }

--- a/src/Exceptions/RuntimeException.php
+++ b/src/Exceptions/RuntimeException.php
@@ -20,9 +20,6 @@ declare(strict_types=1);
  */
 namespace BigBlueButton\Exceptions;
 
-/**
- * @final since 4.0.
- */
-class RuntimeException extends BaseException
+final class RuntimeException extends BaseException
 {
 }

--- a/src/Util/UrlBuilder.php
+++ b/src/Util/UrlBuilder.php
@@ -22,10 +22,9 @@ namespace BigBlueButton\Util;
  * Class UrlBuilder
  * @package BigBlueButton\Util
  *
- * @final since 4.0.
  * @internal
  */
-class UrlBuilder
+final class UrlBuilder
 {
     /**
      * @var string


### PR DESCRIPTION
fix  #121.

The main `BigBlueButton` class is also marked as `@final`. I decided against to also make it final as this is breaking DX too much in my opinion. We would need an Interface to allow that, or you are not able to mock the class anymore. This should be postponed to version 5.1+. For now, it is a reminder, that you *should* not extend the class in your code.

* This PR points to 5.0 branch. 5.0 will be developed with 4.3 in parallel, like explained in https://github.com/littleredbutton/bigbluebutton-api-php/issues/122.
* 5.0 will have the same features as 4.3 minus Deprecations and plus BC Breaks.
* When 4.3 was branched and released, 5.0 branch will be merged back to master. Until this is done, every merge to master requires an "upmerge" to the 5.0 branch.