### PR TITLE
Bump minimum PHP version to 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ on:
 
 jobs:
   PHP_Lowest:
-    name: PHP wth lowest dependencies
+    name: PHP ${{ matrix.php-versions }} wth lowest dependencies
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2']
+        php-versions: ['7.4', '8.0']
         experimental: [false]
 
     steps:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2','7.3','7.4','8.0']
+        php-versions: ['7.4','8.0']
         experimental: [false]
         include:
           - php-versions: '8.1'
@@ -70,5 +70,5 @@ jobs:
     - name: Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ matrix.php-versions == '7.2' && env.COVERALLS_REPO_TOKEN != null }}
+      if: ${{ matrix.php-versions == '7.4' && env.COVERALLS_REPO_TOKEN != null }}
       run: vendor/bin/php-coveralls --coverage_clover=build/logs/coverage.xml -v

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # :tada: Best BigBlueButton API for PHP
 
 The unofficial and easiest to use **BigBlueButton API for PHP**, makes easy for
-developers to use [BigBlueButton API] v2.2+ for **PHP 7.2+**.
+developers to use [BigBlueButton API] v2.2+ for **PHP 7.4+**.
 
 ![Build Status](https://github.com/littleredbutton/bigbluebutton-api-php/workflows/CI/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/littleredbutton/bigbluebutton-api-php/badge.svg?branch=master)](https://coveralls.io/github/littleredbutton/bigbluebutton-api-php?branch=master)
@@ -56,7 +56,7 @@ following advantages:
 - Development is simplified through git hooks and contributor guidelines
 - Documentation is up-to-date and complete
 - API is fixed and extended to exploit the full potential
-- Require at least PHP 7.2, which allows to make the code more efficient and
+- Require at least PHP 7.4, which allows to make the code more efficient and
   readable
 
 ## :gear: Installation and usage
@@ -64,7 +64,7 @@ following advantages:
 In order to use this library you have to make sure to meet the following
 requirements:
 
-- PHP 7.2 or above.
+- PHP 7.4 or above.
 - curl library installed.
 - mbstring library installed.
 - xml library installed.

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "docs": "https://github.com/littleredbutton/bigbluebutton-api-php/blob/master/README.md"
   },
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "ext-curl": "*",
     "ext-simplexml": "*",
     "ext-mbstring": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
          backupStaticAttributes="false"
          bootstrap="./tests/bootstrap.php"
          colors="true"
+         convertDeprecationsToExceptions="false"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"


### PR DESCRIPTION
fix #119

Notes:

* This PR points to 5.0 branch. 5.0 will be developed with 4.3 in parallel, like explained in https://github.com/littleredbutton/bigbluebutton-api-php/issues/122.
* 5.0 will have the same features as 4.3 minus Deprecations and plus BC Breaks.
* When 4.3 was branched and released, 5.0 branch will be merged back to master. Until this is done, every merge to master requires an "upmerge" to the 5.0 branch.