### PR TITLE
Fix inconsistent features const casing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,8 +62,7 @@
     "ext-curl": "*",
     "ext-simplexml": "*",
     "ext-mbstring": "*",
-    "ext-json": "*",
-    "marc-mabe/php-enum": "^4.7"
+    "ext-json": "*"
   },
   "suggest": {
     "psr/http-client-implementation": "To use the PsrHttpClientTransport.",

--- a/src/Enum/Enum.php
+++ b/src/Enum/Enum.php
@@ -3,7 +3,7 @@
 /*
  * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
  *
- * Copyright (c) 2016-2022 BigBlueButton Inc. and by respective authors (see below).
+ * Copyright (c) 2016-2023 BigBlueButton Inc. and by respective authors (see below).
  *
  * This program is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -23,8 +23,12 @@ namespace BigBlueButton\Enum;
 /**
  * @psalm-immutable
  */
-class Role extends Enum
+abstract class Enum
 {
-    public const MODERATOR = 'MODERATOR';
-    public const VIEWER = 'VIEWER';
+    public static function getValues(): array
+    {
+        $reflection = new \ReflectionClass(static::class);
+
+        return $reflection->getConstants();
+    }
 }

--- a/src/Enum/Feature.php
+++ b/src/Enum/Feature.php
@@ -20,8 +20,6 @@
 
 namespace BigBlueButton\Enum;
 
-use MabeEnum\Enum;
-
 /**
  * @psalm-immutable
  */
@@ -32,8 +30,8 @@ class Feature extends Enum
     public const CHAT = 'chat';
     public const DOWNLOAD_PRESENTATION_WITH_ANNOTATIONS = 'downloadPresentationWithAnnotations';
     public const EXTERNAL_VIDEOS = 'externalVideos';
-    public const IMPORT_PRESENTATION_WITHANNOTATIONS_FROM_BREAKOUTROOMS = 'importPresentationWithAnnotationsFromBreakoutRooms';
-    public const IMPORT_SHARED_NOTES_FROM_BREAKOUTROOMS = 'importSharedNotesFromBreakoutRooms';
+    public const IMPORT_PRESENTATION_WITH_ANNOTATIONS_FROM_BREAKOUT_ROOMS = 'importPresentationWithAnnotationsFromBreakoutRooms';
+    public const IMPORT_SHARED_NOTES_FROM_BREAKOUT_ROOMS = 'importSharedNotesFromBreakoutRooms';
     public const LAYOUTS = 'layouts';
     public const LEARNING_DASHBOARD = 'learningDashboard';
     public const POLLS = 'polls';
@@ -48,4 +46,14 @@ class Feature extends Enum
     public const DOWNLOAD_PRESENTATION_ORIGINAL_FILE = 'downloadPresentationOriginalFile';
     public const DOWNLOAD_PRESENTATION_CONVERTED_TO_PDF = 'downloadPresentationConvertedToPdf';
     public const TIMER = 'timer';
+
+    /**
+     * @deprecated Use Feature::IMPORT_PRESENTATION_WITH_ANNOTATIONS_FROM_BREAKOUT_ROOMS instead
+     */
+    public const IMPORT_PRESENTATION_WITHANNOTATIONS_FROM_BREAKOUTROOMS = 'importPresentationWithAnnotationsFromBreakoutRooms';
+
+    /**
+     * @deprecated Use Feature::IMPORT_SHARED_NOTES_FROM_BREAKOUT_ROOMS instead
+     */
+    public const IMPORT_SHARED_NOTES_FROM_BREAKOUTROOMS = 'importSharedNotesFromBreakoutRooms';
 }

--- a/src/Enum/HashingAlgorithm.php
+++ b/src/Enum/HashingAlgorithm.php
@@ -20,8 +20,6 @@
 
 namespace BigBlueButton\Enum;
 
-use MabeEnum\Enum;
-
 /**
  * @psalm-immutable
  */


### PR DESCRIPTION
- Add two new consts for features with the correct casing
- Depracte old const names

- Remove marc-mabe/php-enum dependency
Using marc-mabe/php-enum we cannot have two const with the same value.
However we don't use most of the features of this dependency, therefore just using simple consts and an abstract class for a helper functions is just fine.
With the switch to PHP 8.1. we can remove this and switch to native enums.
