### PR TITLE
Bump minimum PHP version to 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0']
+        php-versions: ['8.1', '8.2']
         experimental: [false]
 
     steps:
@@ -37,13 +37,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4','8.0']
+        php-versions: ['8.1', '8.2']
         experimental: [false]
         include:
-          - php-versions: '8.1'
-            experimental: true
-          - php-versions: '8.2'
-            experimental: true
           - php-versions: '8.3'
             experimental: true
     steps:
@@ -73,5 +69,5 @@ jobs:
     - name: Coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ matrix.php-versions == '7.4' && env.COVERALLS_REPO_TOKEN != null }}
+      if: ${{ matrix.php-versions == '8.1' && env.COVERALLS_REPO_TOKEN != null }}
       run: tools/php-coveralls --coverage_clover=build/logs/coverage.xml -v

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # :tada: Best BigBlueButton API for PHP
 
 The unofficial and easiest to use **BigBlueButton API for PHP**, makes easy for
-developers to use [BigBlueButton API] v2.2+ for **PHP 7.4+**.
+developers to use [BigBlueButton API] v2.2+ for **PHP 8.1+**.
 
 ![Build Status](https://github.com/littleredbutton/bigbluebutton-api-php/workflows/CI/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/littleredbutton/bigbluebutton-api-php/badge.svg?branch=master)](https://coveralls.io/github/littleredbutton/bigbluebutton-api-php?branch=master)
@@ -56,7 +56,7 @@ following advantages:
 - Development is simplified through git hooks and contributor guidelines
 - Documentation is up-to-date and complete
 - API is fixed and extended to exploit the full potential
-- Require at least PHP 7.4, which allows to make the code more efficient and
+- Require at least PHP 8.1, which allows to make the code more efficient and
   readable
 
 ## :gear: Installation and usage
@@ -64,7 +64,7 @@ following advantages:
 In order to use this library you have to make sure to meet the following
 requirements:
 
-- PHP 7.4 or above.
+- PHP 8.1 or above.
 - curl library installed.
 - mbstring library installed.
 - xml library installed.


### PR DESCRIPTION
Fixes #114 

Notes:

- This PR points to 6.0 branch. 6.0 will be developed with 5.2 in parallel, like explained in https://github.com/littleredbutton/bigbluebutton-api-php/issues/122.
- 6.0 will have the same features as 5.2 minus Deprecations and plus BC Breaks.