### PR TITLE
Deprecate password in CreateMeetingResponse

### DIFF
--- a/src/Responses/CreateMeetingResponse.php
+++ b/src/Responses/CreateMeetingResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
  *
@@ -42,11 +43,17 @@ class CreateMeetingResponse extends BaseResponse
         return $this->rawXml->parentMeetingID->__toString();
     }
 
+    /**
+     * @deprecated and will be removed in 6.0. Recent BigBlueButton versions does not require the password parameter in api requests.
+     */
     public function getAttendeePassword(): string
     {
         return $this->rawXml->attendeePW->__toString();
     }
 
+    /**
+     * @deprecated and will be removed in 6.0. Recent BigBlueButton versions does not require the password parameter in api requests.
+     */
     public function getModeratorPassword(): string
     {
         return $this->rawXml->moderatorPW->__toString();


### PR DESCRIPTION
Fixes #173 

This PR should be released as 5.3, so we can remove this in 6.0