### PR TITLE
Recording response errors

### DIFF
--- a/src/Responses/BaseResponseAsJson.php
+++ b/src/Responses/BaseResponseAsJson.php
@@ -50,27 +50,19 @@ abstract class BaseResponseAsJson
         return json_decode(json_encode($this->data), true);
     }
 
-    public function getMessage(): ?string
+    public function getMessage(): string
     {
-        if ($this->failed()) {
-            return $this->data->response->message;
-        }
-
-        return null;
+        return $this->data->response->message ?? '';
     }
 
-    public function getMessageKey(): ?string
+    public function getMessageKey(): string
     {
-        if ($this->failed()) {
-            return $this->data->response->messageKey;
-        }
-
-        return null;
+        return $this->data->response->messageKey ?? '';
     }
 
     public function getReturnCode(): string
     {
-        return $this->data->response->returncode;
+        return $this->data->response->returncode ?? '';
     }
 
     public function success(): bool

--- a/src/Responses/DeleteRecordingsResponse.php
+++ b/src/Responses/DeleteRecordingsResponse.php
@@ -24,6 +24,7 @@ namespace BigBlueButton\Responses;
  */
 class DeleteRecordingsResponse extends BaseResponse
 {
+    /** @deprecated and will be removed in 6.0. Use KEY_NOT_FOUND instead  */
     public const KEY_INVALID_ID = 'InvalidRecordingId';
 
     public const KEY_NOT_FOUND = 'notFound';
@@ -33,6 +34,7 @@ class DeleteRecordingsResponse extends BaseResponse
         return $this->rawXml->deleted->__toString() == 'true';
     }
 
+    /** @deprecated and will be removed in 6.0. Use isNotFound instead  */
     public function isInvalidId(): bool
     {
         return $this->getMessageKey() === self::KEY_INVALID_ID;

--- a/src/Responses/DeleteRecordingsResponse.php
+++ b/src/Responses/DeleteRecordingsResponse.php
@@ -26,6 +26,8 @@ class DeleteRecordingsResponse extends BaseResponse
 {
     public const KEY_INVALID_ID = 'InvalidRecordingId';
 
+    public const KEY_NOT_FOUND = 'notFound';
+
     public function isDeleted(): bool
     {
         return $this->rawXml->deleted->__toString() == 'true';
@@ -34,5 +36,10 @@ class DeleteRecordingsResponse extends BaseResponse
     public function isInvalidId(): bool
     {
         return $this->getMessageKey() === self::KEY_INVALID_ID;
+    }
+
+    public function isNotFound(): bool
+    {
+        return $this->getMessageKey() === self::KEY_NOT_FOUND;
     }
 }

--- a/src/Responses/PublishRecordingsResponse.php
+++ b/src/Responses/PublishRecordingsResponse.php
@@ -24,8 +24,15 @@ namespace BigBlueButton\Responses;
  */
 class PublishRecordingsResponse extends BaseResponse
 {
+    public const KEY_NOT_FOUND = 'notFound';
+
     public function isPublished(): bool
     {
         return $this->rawXml->published->__toString() === 'true';
+    }
+
+    public function isNotFound(): bool
+    {
+        return $this->getMessageKey() === self::KEY_NOT_FOUND;
     }
 }

--- a/src/Responses/PutRecordingTextTrackResponse.php
+++ b/src/Responses/PutRecordingTextTrackResponse.php
@@ -27,6 +27,9 @@ class PutRecordingTextTrackResponse extends BaseResponseAsJson
     public const KEY_SUCCESS = 'upload_text_track_success';
     public const KEY_FAILED = 'upload_text_track_failed';
     public const KEY_EMPTY = 'empty_uploaded_text_track';
+    public const KEY_NO_RECORDINGS = 'noRecordings';
+    public const KEY_INVALID_KIND = 'invalidKind';
+    public const KEY_INVALID_LANG = 'invalidLang';
     public const KEY_PARAM_ERROR = 'paramError';
 
     public function getRecordID(): string
@@ -47,6 +50,21 @@ class PutRecordingTextTrackResponse extends BaseResponseAsJson
     public function isUploadTrackEmpty(): bool
     {
         return $this->getMessageKey() === self::KEY_EMPTY;
+    }
+
+    public function isNoRecordings(): bool
+    {
+        return $this->getMessageKey() === self::KEY_NO_RECORDINGS;
+    }
+
+    public function isInvalidLang(): bool
+    {
+        return $this->getMessageKey() === self::KEY_INVALID_LANG;
+    }
+
+    public function isInvalidKind(): bool
+    {
+        return $this->getMessageKey() === self::KEY_INVALID_KIND;
     }
 
     public function isKeyParamError(): bool

--- a/src/Responses/PutRecordingTextTrackResponse.php
+++ b/src/Responses/PutRecordingTextTrackResponse.php
@@ -34,7 +34,7 @@ class PutRecordingTextTrackResponse extends BaseResponseAsJson
 
     public function getRecordID(): string
     {
-        return $this->data->response->recordId;
+        return $this->data->response->recordId ?? '';
     }
 
     public function isUploadTrackSuccess(): bool

--- a/src/Responses/UpdateRecordingsResponse.php
+++ b/src/Responses/UpdateRecordingsResponse.php
@@ -24,8 +24,15 @@ namespace BigBlueButton\Responses;
  */
 class UpdateRecordingsResponse extends BaseResponse
 {
+    public const KEY_NOT_FOUND = 'notFound';
+
     public function isUpdated(): bool
     {
         return $this->rawXml->updated->__toString() === 'true';
+    }
+
+    public function isNotFound(): bool
+    {
+        return $this->getMessageKey() === self::KEY_NOT_FOUND;
     }
 }

--- a/tests/fixtures/not_found_error.xml
+++ b/tests/fixtures/not_found_error.xml
@@ -1,0 +1,5 @@
+<response>
+    <returncode>FAILED</returncode>
+    <messageKey>notFound</messageKey>
+    <message>We could not find recordings</message>
+</response>

--- a/tests/unit/BigBlueButtonTest.php
+++ b/tests/unit/BigBlueButtonTest.php
@@ -449,8 +449,8 @@ final class BigBlueButtonTest extends TestCase
         $response = $this->bbb->putRecordingTextTrack($params);
 
         $this->assertTrue($response->success());
-        $this->assertNull($response->getMessageKey());
-        $this->assertNull($response->getMessage());
+        $this->assertEquals('upload_text_track_success', $response->getMessageKey());
+        $this->assertEquals('Text track uploaded successfully', $response->getMessage());
         $this->assertSame('baz', $response->getRecordID());
         $this->assertSame('SUCCESS', $response->getReturnCode());
     }

--- a/tests/unit/Responses/DeleteRecordingsResponseTest.php
+++ b/tests/unit/Responses/DeleteRecordingsResponseTest.php
@@ -49,4 +49,14 @@ final class DeleteRecordingsResponseTest extends TestCase
         $this->assertEachGetterValueIsString($this->delete, ['getReturnCode']);
         $this->assertEachGetterValueIsBoolean($this->delete, ['isDeleted']);
     }
+
+    public function testNotFoundError()
+    {
+        $xml = $this->loadXmlFile(__DIR__.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'fixtures'.\DIRECTORY_SEPARATOR.'not_found_error.xml');
+
+        $delete = new DeleteRecordingsResponse($xml);
+
+        $this->assertTrue($delete->failed());
+        $this->assertTrue($delete->isNotFound());
+    }
 }

--- a/tests/unit/Responses/DeleteRecordingsResponseTest.php
+++ b/tests/unit/Responses/DeleteRecordingsResponseTest.php
@@ -50,7 +50,7 @@ final class DeleteRecordingsResponseTest extends TestCase
         $this->assertEachGetterValueIsBoolean($this->delete, ['isDeleted']);
     }
 
-    public function testNotFoundError()
+    public function testNotFoundError(): void
     {
         $xml = $this->loadXmlFile(__DIR__.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'fixtures'.\DIRECTORY_SEPARATOR.'not_found_error.xml');
 

--- a/tests/unit/Responses/PublishRecordingsResponseTest.php
+++ b/tests/unit/Responses/PublishRecordingsResponseTest.php
@@ -50,7 +50,7 @@ final class PublishRecordingsResponseTest extends TestCase
         $this->assertEachGetterValueIsBoolean($this->publish, ['isPublished']);
     }
 
-    public function testNotFoundError()
+    public function testNotFoundError(): void
     {
         $xml = $this->loadXmlFile(__DIR__.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'fixtures'.\DIRECTORY_SEPARATOR.'not_found_error.xml');
 

--- a/tests/unit/Responses/PublishRecordingsResponseTest.php
+++ b/tests/unit/Responses/PublishRecordingsResponseTest.php
@@ -49,4 +49,14 @@ final class PublishRecordingsResponseTest extends TestCase
         $this->assertEachGetterValueIsString($this->publish, ['getReturnCode']);
         $this->assertEachGetterValueIsBoolean($this->publish, ['isPublished']);
     }
+
+    public function testNotFoundError()
+    {
+        $xml = $this->loadXmlFile(__DIR__.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'fixtures'.\DIRECTORY_SEPARATOR.'not_found_error.xml');
+
+        $publish = new PublishRecordingsResponse($xml);
+
+        $this->assertTrue($publish->failed());
+        $this->assertTrue($publish->isNotFound());
+    }
 }

--- a/tests/unit/Responses/PutRecordingTextTrackResponseTest.php
+++ b/tests/unit/Responses/PutRecordingTextTrackResponseTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016-2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace BigBlueButton\Parameters;
+
+use BigBlueButton\Responses\PutRecordingTextTrackResponse;
+use BigBlueButton\TestCase;
+
+final class PutRecordingTextTrackResponseTest extends TestCase
+{
+    public function testUploadSuccess()
+    {
+        $json = '{
+              "response": {
+                "messageKey": "upload_text_track_success",
+                "message": "Text track uploaded successfully",
+                "recordId": "baz",
+                "returncode": "SUCCESS"
+              }
+            }';
+
+        $response = new PutRecordingTextTrackResponse($json);
+
+        $this->assertTrue($response->success());
+        $this->assertEquals('baz', $response->getRecordID());
+        $this->assertTrue($response->isUploadTrackSuccess());
+    }
+
+    public function testUploadFailed()
+    {
+        $json = '{
+              "response": {
+                "messageKey": "upload_text_track_failed",
+                "message": "Text track upload failed.",
+                "recordId": "baz",
+                "returncode": "FAILED"
+              }
+            }';
+
+        $response = new PutRecordingTextTrackResponse($json);
+
+        $this->assertTrue($response->failed());
+        $this->assertEquals('baz', $response->getRecordID());
+        $this->assertTrue($response->isUploadTrackFailed());
+    }
+
+    public function testUploadEmpty()
+    {
+        $json = '{
+              "response": {
+                "messageKey": "empty_uploaded_text_track",
+                "message": "Empty uploaded text track.",
+                "returncode": "FAILED"
+              }
+            }';
+
+        $response = new PutRecordingTextTrackResponse($json);
+
+        $this->assertTrue($response->failed());
+        $this->assertTrue($response->isUploadTrackEmpty());
+    }
+
+    public function testNoRecordings()
+    {
+        $json = '{
+              "response": {
+                "messageKey": "noRecordings",
+                "message": "No recording was found for meeting-id-1234.",
+                "returncode": "FAILED"
+              }
+            }';
+
+        $response = new PutRecordingTextTrackResponse($json);
+
+        $this->assertTrue($response->failed());
+        $this->assertTrue($response->isNoRecordings());
+    }
+
+    public function testInvalidLang()
+    {
+        $json = '{
+              "response": {
+                "messageKey": "invalidLang",
+                "message": "Malformed lang param, received=english",
+                "returncode": "FAILED"
+              }
+            }';
+
+        $response = new PutRecordingTextTrackResponse($json);
+
+        $this->assertTrue($response->failed());
+        $this->assertTrue($response->isInvalidLang());
+    }
+
+    public function testInvalidKind()
+    {
+        $json = '{
+              "response": {
+                "messageKey": "invalidKind",
+                "message": "Invalid kind parameter, expected=\'subtitles|captions\' actual=somethingelse",
+                "returncode": "FAILED"
+              }
+            }';
+
+        $response = new PutRecordingTextTrackResponse($json);
+
+        $this->assertTrue($response->failed());
+        $this->assertTrue($response->isInvalidKind());
+    }
+
+    public function testHandleMissingJsonKeys()
+    {
+        $json = '{}';
+
+        $response = new PutRecordingTextTrackResponse($json);
+
+        $this->assertFalse($response->success());
+        $this->assertFalse($response->failed());
+        $this->assertFalse($response->hasChecksumError());
+        $this->assertEquals('', $response->getRecordID());
+        $this->assertFalse($response->isUploadTrackSuccess());
+        $this->assertFalse($response->isUploadTrackFailed());
+        $this->assertFalse($response->isUploadTrackEmpty());
+        $this->assertFalse($response->isNoRecordings());
+        $this->assertFalse($response->isInvalidLang());
+        $this->assertFalse($response->isInvalidKind());
+    }
+}

--- a/tests/unit/Responses/PutRecordingTextTrackResponseTest.php
+++ b/tests/unit/Responses/PutRecordingTextTrackResponseTest.php
@@ -24,7 +24,7 @@ use BigBlueButton\TestCase;
 
 final class PutRecordingTextTrackResponseTest extends TestCase
 {
-    public function testUploadSuccess()
+    public function testUploadSuccess(): void
     {
         $json = '{
               "response": {
@@ -42,7 +42,7 @@ final class PutRecordingTextTrackResponseTest extends TestCase
         $this->assertTrue($response->isUploadTrackSuccess());
     }
 
-    public function testUploadFailed()
+    public function testUploadFailed(): void
     {
         $json = '{
               "response": {
@@ -60,7 +60,7 @@ final class PutRecordingTextTrackResponseTest extends TestCase
         $this->assertTrue($response->isUploadTrackFailed());
     }
 
-    public function testUploadEmpty()
+    public function testUploadEmpty(): void
     {
         $json = '{
               "response": {
@@ -76,7 +76,7 @@ final class PutRecordingTextTrackResponseTest extends TestCase
         $this->assertTrue($response->isUploadTrackEmpty());
     }
 
-    public function testNoRecordings()
+    public function testNoRecordings(): void
     {
         $json = '{
               "response": {
@@ -92,7 +92,7 @@ final class PutRecordingTextTrackResponseTest extends TestCase
         $this->assertTrue($response->isNoRecordings());
     }
 
-    public function testInvalidLang()
+    public function testInvalidLang(): void
     {
         $json = '{
               "response": {
@@ -108,7 +108,7 @@ final class PutRecordingTextTrackResponseTest extends TestCase
         $this->assertTrue($response->isInvalidLang());
     }
 
-    public function testInvalidKind()
+    public function testInvalidKind(): void
     {
         $json = '{
               "response": {
@@ -124,7 +124,7 @@ final class PutRecordingTextTrackResponseTest extends TestCase
         $this->assertTrue($response->isInvalidKind());
     }
 
-    public function testHandleMissingJsonKeys()
+    public function testHandleMissingJsonKeys(): void
     {
         $json = '{}';
 

--- a/tests/unit/Responses/UpdateRecordingsResponseTest.php
+++ b/tests/unit/Responses/UpdateRecordingsResponseTest.php
@@ -49,4 +49,14 @@ final class UpdateRecordingsResponseTest extends TestCase
         $this->assertEachGetterValueIsString($this->update, ['getReturnCode']);
         $this->assertEachGetterValueIsBoolean($this->update, ['isUpdated']);
     }
+
+    public function testNotFoundError()
+    {
+        $xml = $this->loadXmlFile(__DIR__.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'fixtures'.\DIRECTORY_SEPARATOR.'not_found_error.xml');
+
+        $update = new UpdateRecordingsResponse($xml);
+
+        $this->assertTrue($update->failed());
+        $this->assertTrue($update->isNotFound());
+    }
 }

--- a/tests/unit/Responses/UpdateRecordingsResponseTest.php
+++ b/tests/unit/Responses/UpdateRecordingsResponseTest.php
@@ -50,7 +50,7 @@ final class UpdateRecordingsResponseTest extends TestCase
         $this->assertEachGetterValueIsBoolean($this->update, ['isUpdated']);
     }
 
-    public function testNotFoundError()
+    public function testNotFoundError(): void
     {
         $xml = $this->loadXmlFile(__DIR__.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'fixtures'.\DIRECTORY_SEPARATOR.'not_found_error.xml');
 


### PR DESCRIPTION
Fixes #180 

- Add `isNotFound()` to PublishRecordingsResponse, UpdateRecordingsResponse and DeleteRecordingsResponse
- Deprecated `isInvalidId()` in DeleteRecordingsResponse
- Add `isNoRecordings()`, `isInvalidLang()`, `isInvalidKind()` in PutRecordingTextTrackResponse (see https://docs.bigbluebutton.org/development/api/#putrecordingtexttrack)
- Change the behaviour of json responses to non-existent json keys by no longer throwing exceptions but returning an empty string instead (same as the xml responses)