### PR TITLE
Add missing tests

### DIFF
--- a/src/Core/Record.php
+++ b/src/Core/Record.php
@@ -36,6 +36,9 @@ class Record
 
     /** @var PlaybackFormat[] */
     private $playbackFormats = [];
+    private $playbackType;
+    private $playbackUrl;
+    private $playbackLength;
 
     public function __construct(\SimpleXMLElement $xml)
     {

--- a/tests/fixtures/create_meeting_not_unique_error.xml
+++ b/tests/fixtures/create_meeting_not_unique_error.xml
@@ -1,0 +1,5 @@
+<response>
+    <returncode>FAILED</returncode>
+    <messageKey>idNotUnique</messageKey>
+    <message>A meeting already exists with that meeting ID.  Please use a different meeting ID.</message>
+</response>

--- a/tests/unit/Parameters/CreateMeetingParametersTest.php
+++ b/tests/unit/Parameters/CreateMeetingParametersTest.php
@@ -107,6 +107,27 @@ final class CreateMeetingParametersTest extends TestCase
         $this->assertEquals($newId, $createMeetingParams->getMeetingID());
     }
 
+    public function testMetaParameters(): void
+    {
+        $params = $this->generateCreateParams();
+        $createMeetingParams = $this->getCreateMock($params);
+        $createMeetingParams->addMeta('userdata-bbb_hide_presentation_on_join', true);
+        $createMeetingParams->addMeta('userdata-bbb_show_participants_on_login', false);
+        $createMeetingParams->addMeta('userdata-bbb_fullaudio_bridge', 'fullaudio');
+
+        // Test getters
+        $this->assertTrue($createMeetingParams->getMeta('userdata-bbb_hide_presentation_on_join'));
+        $this->assertFalse($createMeetingParams->getMeta('userdata-bbb_show_participants_on_login'));
+        $this->assertEquals('fullaudio', $createMeetingParams->getMeta('userdata-bbb_fullaudio_bridge'));
+
+        $params = urldecode($createMeetingParams->getHTTPQuery());
+
+        // Test HTTP query
+        $this->assertStringContainsString('meta_userdata-bbb_hide_presentation_on_join=true', $params);
+        $this->assertStringContainsString('meta_userdata-bbb_show_participants_on_login=false', $params);
+        $this->assertStringContainsString('meta_userdata-bbb_fullaudio_bridge=fullaudio', $params);
+    }
+
     public function testDisabledFeatures(): void
     {
         $params = $this->generateCreateParams();

--- a/tests/unit/Parameters/InsertDocumentParametersTest.php
+++ b/tests/unit/Parameters/InsertDocumentParametersTest.php
@@ -25,14 +25,19 @@ use BigBlueButton\TestCase;
 
 final class InsertDocumentParametersTest extends TestCase
 {
-    public function testIsMeetingRunningParameters(): void
+    public function testInsertingDocuments(): void
     {
         $meetingId = $this->faker->uuid;
         $params = new InsertDocumentParameters($meetingId);
 
+        // Adding presentations
         $params->addPresentation('http://localhost/foobar.png', 'Foobar.png');
         $params->addPresentation('http://localhost/foobar.pdf', 'Foobar.pdf', true);
         $params->addPresentation('http://localhost/foobar.svg', 'Foobar.svg', true, false);
+        $params->addPresentation('http://localhost/demo.pdf', 'Demo.pdf', true);
+
+        // Removing presentation
+        $params->removePresentation('http://localhost/demo.pdf');
 
         $this->assertEquals($meetingId, $params->getMeetingID());
 

--- a/tests/unit/Responses/CreateMeetingResponseTest.php
+++ b/tests/unit/Responses/CreateMeetingResponseTest.php
@@ -40,7 +40,10 @@ final class CreateMeetingResponseTest extends TestCase
 
     public function testCreateMeetingResponseContent()
     {
+        $this->assertTrue($this->meeting->success());
+        $this->assertFalse($this->meeting->failed());
         $this->assertEquals('SUCCESS', $this->meeting->getReturnCode());
+
         $this->assertEquals('random-1665177', $this->meeting->getMeetingId());
         $this->assertEquals('1a6938c707cdf5d052958672d66c219c30690c47-1524212045514', $this->meeting->getInternalMeetingId());
         $this->assertEquals('bbb-none', $this->meeting->getParentMeetingId());
@@ -54,7 +57,10 @@ final class CreateMeetingResponseTest extends TestCase
         $this->assertEquals(20, $this->meeting->getDuration());
         $this->assertFalse($this->meeting->hasBeenForciblyEnded());
         $this->assertEquals('duplicateWarning', $this->meeting->getMessageKey());
+        $this->assertTrue($this->meeting->isDuplicate());
         $this->assertEquals('This conference was already in existence and may currently be in progress.', $this->meeting->getMessage());
+
+        $this->assertFalse($this->meeting->isIdNotUnique());
     }
 
     public function testCreateMeetingResponseTypes()
@@ -64,5 +70,18 @@ final class CreateMeetingResponseTest extends TestCase
         $this->assertEachGetterValueIsDouble($this->meeting, ['getCreationTime']);
         $this->assertEachGetterValueIsInteger($this->meeting, ['getDuration', 'getVoiceBridge']);
         $this->assertEachGetterValueIsBoolean($this->meeting, ['hasUserJoined', 'hasBeenForciblyEnded']);
+    }
+
+    public function testIdNotUnique()
+    {
+        $xml = $this->loadXmlFile(__DIR__.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'fixtures'.\DIRECTORY_SEPARATOR.'create_meeting_not_unique_error.xml');
+
+        $meeting = new CreateMeetingResponse($xml);
+
+        $this->assertFalse($meeting->success());
+        $this->assertTrue($meeting->failed());
+        $this->assertEquals('FAILED', $meeting->getReturnCode());
+
+        $this->assertTrue($meeting->isIdNotUnique());
     }
 }

--- a/tests/unit/Responses/GetRecordingsResponseTest.php
+++ b/tests/unit/Responses/GetRecordingsResponseTest.php
@@ -111,5 +111,11 @@ final class GetRecordingsResponseTest extends TestCase
 
         $this->assertEquals('Welcome to', $previews[0]->getAlt());
         $this->assertEquals('https://demo.bigbluebutton.org/presentation/ffbfc4cc24428694e8b53a4e144f414052431693-1530718721124/presentation/d2d9a672040fbde2a47a10bf6c37b6a4b5ae187f-1530718721134/thumbnails/thumb-1.png', $previews[0]->getUrl());
+        $this->assertEquals(176, $previews[0]->getWidth());
+        $this->assertEquals(136, $previews[0]->getHeight());
+
+        // Load previews again, check if same instance is returned (caching)
+        $newPreviews = $formats[1]->getImagePreviews();
+        $this->assertTrue($previews[0] === $newPreviews[0]);
     }
 }


### PR DESCRIPTION
- Added tests to reach full coverage.
- Added missing properties (Dynamic Properties are deprecated since PHP 8.2)

During this process I discovered a few areas that needed some improvement: #184 and #181
If all three PRs are merged, we should have a near 100% coverage.

