### PR TITLE
Update Webhook api calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,10 +75,10 @@
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
-    "symfony/dotenv": "^5.4|^6.4|^7.0",
+    "symfony/dotenv": "^3.4|^4.0|^5.0",
     "symfony/http-client-contracts": "^1.1|^2.0",
-    "symfony/http-client": "^5.4|^6.4|^7.0",
-    "symfony/process": "^5.4|^6.4|^7.0",
+    "symfony/http-client": "^4.4|^5.0",
+    "symfony/process": "^3.4|^4.0|^5.0",
     "nyholm/psr7": "^1.4"
   },
   "autoload": {

--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -419,7 +419,7 @@ class BigBlueButton
         return new HooksCreateResponse($xml);
     }
 
-    public function getHooksListUrl(HooksListParameters $hooksListParameters = null): string
+    public function getHooksListUrl(?HooksListParameters $hooksListParameters = null): string
     {
         if ($hooksListParameters === null) {
             @trigger_error(sprintf('Not passing the $hooksListParameters parameter to "%s::getHooksListUrl()" is deprecated since 5.4 and will be required in 6.0.', self::class), \E_USER_DEPRECATED);
@@ -429,7 +429,7 @@ class BigBlueButton
         return $this->urlBuilder->buildUrl(ApiMethod::HOOKS_LIST, $hooksListParameters->getHTTPQuery());
     }
 
-    public function hooksList(HooksListParameters $hooksListParameters = null): HooksListResponse
+    public function hooksList(?HooksListParameters $hooksListParameters = null): HooksListResponse
     {
         if ($hooksListParameters === null) {
             @trigger_error(sprintf('Not passing the $hooksListParameters parameter to "%s::hooksList()" is deprecated since 5.4 and will be required in 6.0.', self::class), \E_USER_DEPRECATED);

--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -419,13 +419,23 @@ class BigBlueButton
         return new HooksCreateResponse($xml);
     }
 
-    public function getHooksListUrl(HooksListParameters $hooksListParameters): string
+    public function getHooksListUrl(HooksListParameters $hooksListParameters = null): string
     {
+        if ($hooksListParameters === null) {
+            @trigger_error(sprintf('Not passing the $hooksListParameters parameter to "%s::getHooksListUrl()" is deprecated since 5.4 and will be required in 6.0.', self::class), \E_USER_DEPRECATED);
+            $hooksListParameters = new HooksListParameters();
+        }
+
         return $this->urlBuilder->buildUrl(ApiMethod::HOOKS_LIST, $hooksListParameters->getHTTPQuery());
     }
 
-    public function hooksList(HooksListParameters $hooksListParameters): HooksListResponse
+    public function hooksList(HooksListParameters $hooksListParameters = null): HooksListResponse
     {
+        if ($hooksListParameters === null) {
+            @trigger_error(sprintf('Not passing the $hooksListParameters parameter to "%s::hooksList()" is deprecated since 5.4 and will be required in 6.0.', self::class), \E_USER_DEPRECATED);
+            $hooksListParameters = new HooksListParameters();
+        }
+
         $xml = $this->processXmlResponse($this->getHooksListUrl($hooksListParameters));
 
         return new HooksListResponse($xml);

--- a/src/BigBlueButton.php
+++ b/src/BigBlueButton.php
@@ -36,6 +36,7 @@ use BigBlueButton\Parameters\GetRecordingsParameters;
 use BigBlueButton\Parameters\GetRecordingTextTracksParameters;
 use BigBlueButton\Parameters\HooksCreateParameters;
 use BigBlueButton\Parameters\HooksDestroyParameters;
+use BigBlueButton\Parameters\HooksListParameters;
 use BigBlueButton\Parameters\InsertDocumentParameters;
 use BigBlueButton\Parameters\IsMeetingRunningParameters;
 use BigBlueButton\Parameters\JoinMeetingParameters;
@@ -418,14 +419,14 @@ class BigBlueButton
         return new HooksCreateResponse($xml);
     }
 
-    public function getHooksListUrl(): string
+    public function getHooksListUrl(HooksListParameters $hooksListParameters): string
     {
-        return $this->urlBuilder->buildUrl(ApiMethod::HOOKS_LIST);
+        return $this->urlBuilder->buildUrl(ApiMethod::HOOKS_LIST, $hooksListParameters->getHTTPQuery());
     }
 
-    public function hooksList(): HooksListResponse
+    public function hooksList(HooksListParameters $hooksListParameters): HooksListResponse
     {
-        $xml = $this->processXmlResponse($this->getHooksListUrl());
+        $xml = $this->processXmlResponse($this->getHooksListUrl($hooksListParameters));
 
         return new HooksListResponse($xml);
     }

--- a/src/Parameters/HooksCreateParameters.php
+++ b/src/Parameters/HooksCreateParameters.php
@@ -24,6 +24,8 @@ namespace BigBlueButton\Parameters;
  * @method $this     setCallbackURL(string $url)
  * @method string    getMeetingID()
  * @method $this     setMeetingID(string $id)
+ * @method string    getEventID()
+ * @method $this     setEventID(string $id)
  * @method bool|null isGetRaw()
  * @method $this     setGetRaw(bool $getRaw)
  */
@@ -38,6 +40,11 @@ class HooksCreateParameters extends BaseParameters
      * @var string
      */
     protected $meetingID;
+
+    /**
+     * @var string
+     */
+    protected $eventID;
 
     /**
      * @var bool

--- a/src/Parameters/HooksListParameters.php
+++ b/src/Parameters/HooksListParameters.php
@@ -25,7 +25,7 @@ namespace BigBlueButton\Parameters;
  * @method string getMeetingID()
  * @method $this  setMeetingID(string $id)
  */
-class HooksListParameters extends MetaParameters
+final class HooksListParameters extends MetaParameters
 {
     /**
      * @var string

--- a/src/Parameters/HooksListParameters.php
+++ b/src/Parameters/HooksListParameters.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016-2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace BigBlueButton\Parameters;
+
+/**
+ * Class HooksListParameters.
+ *
+ * @method string getMeetingID()
+ * @method $this  setMeetingID(string $id)
+ */
+class HooksListParameters extends MetaParameters
+{
+    /**
+     * @var string
+     */
+    protected $meetingID;
+}

--- a/src/Responses/HooksDestroyResponse.php
+++ b/src/Responses/HooksDestroyResponse.php
@@ -24,8 +24,21 @@ namespace BigBlueButton\Responses;
  */
 class HooksDestroyResponse extends BaseResponse
 {
+    public const KEY_MISSING_HOOK = 'destroyMissingHook';
+    public const KEY_HOOK_ERROR = 'destroyHookError';
+
     public function removed(): bool
     {
         return $this->rawXml->removed->__toString() === 'true';
+    }
+
+    public function isMissingHook(): bool
+    {
+        return $this->getMessageKey() === self::KEY_MISSING_HOOK;
+    }
+
+    public function isHookError(): bool
+    {
+        return $this->getMessageKey() === self::KEY_HOOK_ERROR;
     }
 }

--- a/tests/unit/BigBlueButtonTest.php
+++ b/tests/unit/BigBlueButtonTest.php
@@ -525,6 +525,66 @@ final class BigBlueButtonTest extends TestCase
         $this->assertFalse($globalHook->hasRawData());
     }
 
+    /**
+     * @group legacy
+     */
+    public function testHooksListWithoutParameter(): void
+    {
+        $xml = '<response>
+          <returncode>SUCCESS</returncode>
+          <hooks>
+            <hook>
+              <hookID>1</hookID>
+              <callbackURL><![CDATA[http://postcatcher.in/catchers/abcdefghijk]]></callbackURL>
+              <meetingID><![CDATA[my-meeting]]></meetingID>
+              <permanentHook>false</permanentHook>
+              <rawData>false</rawData>
+            </hook>
+            <hook>
+              <hookID>2</hookID>
+              <callbackURL><![CDATA[http://postcatcher.in/catchers/1234567890]]></callbackURL>
+              <permanentHook>false</permanentHook>
+              <rawData>false</rawData>
+            </hook>
+          </hooks>
+        </response>';
+
+        $this->transport->method('request')->willReturn(new TransportResponse($xml, null));
+
+        $response = $this->bbb->hooksList();
+
+        $this->assertTrue($response->success());
+        $this->assertCount(2, $response->getHooks());
+    }
+
+    public function testHooksListUrl(): void
+    {
+        // Test without meeting ID
+        $params = new HooksListParameters();
+        $url = $this->bbb->getHooksListUrl($params);
+
+        $this->assertStringContainsString(ApiMethod::HOOKS_LIST, $url);
+        $this->assertStringNotContainsString('meetingID=', $url);
+
+        // Test with meeting ID
+        $params = new HooksListParameters();
+        $params->setMeetingID('foobar');
+        $url = $this->bbb->getHooksListUrl($params);
+
+        $this->assertStringContainsString('meetingID=foobar', $url);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testHooksListUrlWithoutParameter(): void
+    {
+        $url = $this->bbb->getHooksListUrl();
+
+        $this->assertStringContainsString(ApiMethod::HOOKS_LIST, $url);
+        $this->assertStringNotContainsString('meetingID=', $url);
+    }
+
     public function testHookDestroy(): void
     {
         $params = new HooksDestroyParameters(1);

--- a/tests/unit/BigBlueButtonTest.php
+++ b/tests/unit/BigBlueButtonTest.php
@@ -29,6 +29,9 @@ use BigBlueButton\Http\Transport\TransportResponse;
 use BigBlueButton\Parameters\DeleteRecordingsParameters;
 use BigBlueButton\Parameters\GetRecordingsParameters;
 use BigBlueButton\Parameters\GetRecordingTextTracksParameters;
+use BigBlueButton\Parameters\HooksCreateParameters;
+use BigBlueButton\Parameters\HooksDestroyParameters;
+use BigBlueButton\Parameters\HooksListParameters;
 use BigBlueButton\Parameters\InsertDocumentParameters;
 use BigBlueButton\Parameters\PublishRecordingsParameters;
 use BigBlueButton\Parameters\PutRecordingTextTrackParameters;
@@ -453,5 +456,89 @@ final class BigBlueButtonTest extends TestCase
         $this->assertNull($response->getMessage());
         $this->assertSame('baz', $response->getRecordID());
         $this->assertSame('SUCCESS', $response->getReturnCode());
+    }
+
+    public function testHooksCreate(): void
+    {
+        $params = new HooksCreateParameters($this->faker->url);
+
+        $xml = '<response>
+          <returncode>SUCCESS</returncode>
+          <hookID>1</hookID>
+          <permanentHook>false</permanentHook>
+          <rawData>false</rawData>
+        </response>';
+
+        $this->transport->method('request')->willReturn(new TransportResponse($xml, null));
+
+        $response = $this->bbb->hooksCreate($params);
+
+        $this->assertTrue($response->success());
+        $this->assertSame(1, $response->getHookId());
+        $this->assertFalse($response->isPermanentHook());
+        $this->assertFalse($response->hasRawData());
+    }
+
+    public function testHooksList(): void
+    {
+        $params = new HooksListParameters();
+
+        $xml = '<response>
+          <returncode>SUCCESS</returncode>
+          <hooks>
+            <hook>
+              <hookID>1</hookID>
+              <callbackURL><![CDATA[http://postcatcher.in/catchers/abcdefghijk]]></callbackURL>
+              <meetingID><![CDATA[my-meeting]]></meetingID>
+              <permanentHook>false</permanentHook>
+              <rawData>false</rawData>
+            </hook>
+            <hook>
+              <hookID>2</hookID>
+              <callbackURL><![CDATA[http://postcatcher.in/catchers/1234567890]]></callbackURL>
+              <permanentHook>false</permanentHook>
+              <rawData>false</rawData>
+            </hook>
+          </hooks>
+        </response>';
+
+        $this->transport->method('request')->willReturn(new TransportResponse($xml, null));
+
+        $response = $this->bbb->hooksList($params);
+
+        $this->assertTrue($response->success());
+        $this->assertCount(2, $response->getHooks());
+
+        // Hook for a single meeting
+        $meetingHook = $response->getHooks()[0];
+        $this->assertSame(1, $meetingHook->getHookId());
+        $this->assertSame('http://postcatcher.in/catchers/abcdefghijk', $meetingHook->getCallbackURL());
+        $this->assertSame('my-meeting', $meetingHook->getMeetingID());
+        $this->assertFalse($meetingHook->isPermanentHook());
+        $this->assertFalse($meetingHook->hasRawData());
+
+        // Global hook
+        $globalHook = $response->getHooks()[1];
+        $this->assertSame(2, $globalHook->getHookId());
+        $this->assertSame('http://postcatcher.in/catchers/1234567890', $globalHook->getCallbackURL());
+        $this->assertFalse($globalHook->isPermanentHook());
+        $this->assertFalse($globalHook->hasRawData());
+    }
+
+    public function testHookDestroy(): void
+    {
+        $params = new HooksDestroyParameters(1);
+
+        $xml = '<response>
+          <returncode>SUCCESS</returncode>
+          <removed>true</removed>
+        </response>';
+
+        $this->transport->method('request')->willReturn(new TransportResponse($xml, null));
+
+        $response = $this->bbb->hooksDestroy($params);
+
+        $this->assertTrue($response->success());
+        $this->assertTrue($response->removed());
     }
 }

--- a/tests/unit/Parameters/HooksListParametersTest.php
+++ b/tests/unit/Parameters/HooksListParametersTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016-2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace unit\Parameters;
+
+use BigBlueButton\Parameters\HooksListParameters;
+use BigBlueButton\TestCase;
+
+final class HooksListParametersTest extends TestCase
+{
+    public function testHooksListParameters()
+    {
+        $hooksListParameters = new HooksListParameters();
+
+        $this->assertNull($hooksListParameters->getMeetingID());
+
+        // Test setters that are ignored by the constructor
+        $hooksListParameters->setMeetingID($meetingId = $this->faker->uuid);
+        $this->assertEquals($meetingId, $hooksListParameters->getMeetingID());
+    }
+}

--- a/tests/unit/Parameters/HooksListParametersTest.php
+++ b/tests/unit/Parameters/HooksListParametersTest.php
@@ -17,9 +17,8 @@
  * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace unit\Parameters;
+namespace BigBlueButton\Parameters;
 
-use BigBlueButton\Parameters\HooksListParameters;
 use BigBlueButton\TestCase;
 
 final class HooksListParametersTest extends TestCase

--- a/tests/unit/Parameters/HooksListParametersTest.php
+++ b/tests/unit/Parameters/HooksListParametersTest.php
@@ -23,7 +23,7 @@ use BigBlueButton\TestCase;
 
 final class HooksListParametersTest extends TestCase
 {
-    public function testHooksListParameters()
+    public function testHooksListParameters(): void
     {
         $hooksListParameters = new HooksListParameters();
 

--- a/tests/unit/Responses/HooksDestroyResponseTest.php
+++ b/tests/unit/Responses/HooksDestroyResponseTest.php
@@ -49,4 +49,22 @@ final class HooksDestroyResponseTest extends TestCase
         $this->assertEachGetterValueIsString($this->destroyResponse, ['getReturnCode']);
         $this->assertEachGetterValueIsBoolean($this->destroyResponse, ['removed']);
     }
+
+    public function testHookDestroyMissingHook()
+    {
+        $xml = simplexml_load_string('<response><returncode>FAILED</returncode><messageKey>destroyMissingHook</messageKey><message>The hook informed was not found.</message></response>');
+
+        $destroyResponse = new HooksDestroyResponse($xml);
+        $this->assertTrue($destroyResponse->failed());
+        $this->assertTrue($destroyResponse->isMissingHook());
+    }
+
+    public function testHookDestroyHookError()
+    {
+        $xml = simplexml_load_string('<response><returncode>FAILED</returncode><messageKey>destroyHookError</messageKey><message>An error happened while removing your hook. Check the logs.</message></response>');
+
+        $destroyResponse = new HooksDestroyResponse($xml);
+        $this->assertTrue($destroyResponse->failed());
+        $this->assertTrue($destroyResponse->isHookError());
+    }
 }

--- a/tests/unit/Responses/HooksDestroyResponseTest.php
+++ b/tests/unit/Responses/HooksDestroyResponseTest.php
@@ -50,7 +50,7 @@ final class HooksDestroyResponseTest extends TestCase
         $this->assertEachGetterValueIsBoolean($this->destroyResponse, ['removed']);
     }
 
-    public function testHookDestroyMissingHook()
+    public function testHookDestroyMissingHook(): void
     {
         $xml = simplexml_load_string('<response><returncode>FAILED</returncode><messageKey>destroyMissingHook</messageKey><message>The hook informed was not found.</message></response>');
 
@@ -59,7 +59,7 @@ final class HooksDestroyResponseTest extends TestCase
         $this->assertTrue($destroyResponse->isMissingHook());
     }
 
-    public function testHookDestroyHookError()
+    public function testHookDestroyHookError(): void
     {
         $xml = simplexml_load_string('<response><returncode>FAILED</returncode><messageKey>destroyHookError</messageKey><message>An error happened while removing your hook. Check the logs.</message></response>');
 


### PR DESCRIPTION
Fixes #183

- Add new `HooksListParameters` class as required parameter for `hooksList()` and `getHooksListUrl()` (**Breaking Change**)  (see https://docs.bigbluebutton.org/development/webhooks/#hookslist)
- Add `getEventID()` / `setEventID(string $id)` on HooksCreateParameters  (see https://docs.bigbluebutton.org/development/webhooks/#hookscreate)
- Add `isMissingHook()` and `isHookError()` to HooksDestroyResponse (see https://docs.bigbluebutton.org/development/webhooks/#hooksdestroy)