### PR TITLE
- getting the internal meeting-id from the meeting of the recording

### DIFF
--- a/src/Core/Record.php
+++ b/src/Core/Record.php
@@ -29,6 +29,7 @@ class Record
 {
     private readonly string $recordId;
     private readonly string $meetingId;
+    private readonly string $internalMeetingId;
     private readonly string $name;
     private readonly bool $isPublished;
     private readonly string $state;
@@ -45,6 +46,7 @@ class Record
     {
         $this->recordId = $xml->recordID->__toString();
         $this->meetingId = $xml->meetingID->__toString();
+        $this->internalMeetingId = $xml->internalMeetingID->__toString();
         $this->name = $xml->name->__toString();
         $this->isPublished = $xml->published->__toString() === 'true';
         $this->state = $xml->state->__toString();
@@ -69,6 +71,11 @@ class Record
     public function getMeetingId(): string
     {
         return $this->meetingId;
+    }
+
+    public function getInternalMeetingId(): string
+    {
+        return $this->internalMeetingId;
     }
 
     public function getName(): string

--- a/tests/unit/BigBlueButtonTest.php
+++ b/tests/unit/BigBlueButtonTest.php
@@ -380,6 +380,7 @@ final class BigBlueButtonTest extends TestCase
                 <recording>
                     <recordID>f71d810b6e90a4a34ae02b8c7143e8733178578e-1462807897120</recordID>
                     <meetingID>9d287cf50490ca856ca5273bd303a7e321df6051-4-119</meetingID>
+                    <internalMeetingID>c654308ef4b71eeb74eb8436dc52a31415d9a911-1724671588959</internalMeetingID>
                     <name><![CDATA[SAT- Writing-Humanities (All participants)]]></name>
                     <published>true</published>
                     <state>published</state>
@@ -415,6 +416,7 @@ final class BigBlueButtonTest extends TestCase
         $recording = $response->getRecords()[0];
         $this->assertEquals('f71d810b6e90a4a34ae02b8c7143e8733178578e-1462807897120', $recording->getRecordID());
         $this->assertEquals('9d287cf50490ca856ca5273bd303a7e321df6051-4-119', $recording->getMeetingID());
+        $this->assertEquals('c654308ef4b71eeb74eb8436dc52a31415d9a911-1724671588959', $recording->getInternalMeetingID());
         $this->assertEquals('SAT- Writing-Humanities (All participants)', $recording->getName());
     }
 


### PR DESCRIPTION
If the user or a plugin create more than 1 meeting with the same meetingId, we got records from the false meeting. So I have to check the "internal Meeting-ID" of the recording with the meeting after getting from the api.

This merge request extends the Record class with the "internalMeetingId" of the recording.