### PR TITLE
Fix wrong userReactions feature enum case

### DIFF
--- a/src/Enum/Feature.php
+++ b/src/Enum/Feature.php
@@ -56,7 +56,9 @@ enum Feature: string
     case REPLY_CHAT_MESSAGE = 'replyChatMessage';
     case CHAT_MESSAGE_REACTIONS = 'chatMessageReactions';
     case RAISE_HAND = 'raiseHand';
+    /** @deprecated BC only. Use Feature::USER_REACTIONS instead. */
     case USER_ACTIONS = 'userActions';
+    case USER_REACTIONS = 'userReactions';
     case CHAT_EMOJI_PICKER = 'chatEmojiPicker';
     case QUIZZES = 'quizzes';
 }


### PR DESCRIPTION
"Update feature enum for BBB 3.0" (littleredbutton/bigbluebutton-api-php#225) introduced new cases for the Feature enum.

The BBB feature `userReactions` was mis-spelled and included as `userActions` (case `USER_ACTIONS`).

Add the correct `USER_REACTIONS` case with value `userReactions`.

Keep the wrong `USER_ACTIONS` case to not break existing (changing its value to userReactions is not possible as PHP enums do not allow duplicate values).

See https://docs.bigbluebutton.org/development/api/#updates-to-api-in-bigbluebutton