### PR TITLE
Refactor presentation files

### DIFF
--- a/src/Core/InlinePresentation.php
+++ b/src/Core/InlinePresentation.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace BigBlueButton\Core;
 
+use BigBlueButton\Util\SimpleXMLElementExtended;
+
 class InlinePresentation extends Presentation
 {
     public function __construct(private readonly string $content, string $filename)
@@ -29,15 +31,16 @@ class InlinePresentation extends Presentation
         $this->filename = $filename;
     }
 
-    public function getArrayKey()
+    public function getArrayKey(): string
     {
         return $this->filename;
     }
 
-    public function addDocumentToXML(\SimpleXMLElement $module): ?\SimpleXMLElement
+    public function addDocumentToXML(SimpleXMLElementExtended $module): ?SimpleXMLElementExtended
     {
         $document = parent::addDocumentToXML($module);
 
+        /* @phpstan-ignore-next-line */
         $document[0] = base64_encode($this->content);
 
         if (isset($this->filename)) {

--- a/src/Core/InlinePresentation.php
+++ b/src/Core/InlinePresentation.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016-2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace BigBlueButton\Core;
+
+class InlinePresentation extends Presentation
+{
+    public function __construct(private readonly string $content, string $filename)
+    {
+        $this->filename = $filename;
+    }
+
+    public function getArrayKey()
+    {
+        return $this->filename;
+    }
+
+    public function addDocumentToXML(\SimpleXMLElement $module): ?\SimpleXMLElement
+    {
+        $document = parent::addDocumentToXML($module);
+
+        $document[0] = base64_encode($this->content);
+
+        if (isset($this->filename)) {
+            $document->addAttribute('name', $this->filename);
+        }
+
+        return $document;
+    }
+}

--- a/src/Core/InlinePresentation.php
+++ b/src/Core/InlinePresentation.php
@@ -24,7 +24,7 @@ namespace BigBlueButton\Core;
 
 use BigBlueButton\Util\SimpleXMLElementExtended;
 
-class InlinePresentation extends Presentation
+final class InlinePresentation extends Presentation
 {
     public function __construct(private readonly string $content, string $filename)
     {

--- a/src/Core/Presentation.php
+++ b/src/Core/Presentation.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016-2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace BigBlueButton\Core;
+
+abstract class Presentation
+{
+    protected ?string $filename = null;
+
+    protected ?bool $current = null;
+
+    protected ?bool $downloadable = null;
+
+    protected ?bool $removable = null;
+
+    public function addDocumentToXML(\SimpleXMLElement $module): ?\SimpleXMLElement
+    {
+        $document = $module->addChild('document');
+
+        if (\is_bool($this->downloadable)) {
+            $document->addAttribute('downloadable', $this->downloadable ? 'true' : 'false');
+        }
+
+        if (\is_bool($this->removable)) {
+            $document->addAttribute('removable', $this->removable ? 'true' : 'false');
+        }
+
+        if (\is_bool($this->current)) {
+            $document->addAttribute('current', $this->current ? 'true' : 'false');
+        }
+
+        return $document;
+    }
+
+    public function getFilename(): ?string
+    {
+        return $this->filename;
+    }
+
+    public function setFilename(string $filename): self
+    {
+        $this->filename = $filename;
+
+        return $this;
+    }
+
+    public function getCurrent(): ?bool
+    {
+        return $this->current;
+    }
+
+    public function setCurrent(bool $current): self
+    {
+        $this->current = $current;
+
+        return $this;
+    }
+
+    public function getDownloadable(): ?bool
+    {
+        return $this->downloadable;
+    }
+
+    public function setDownloadable(bool $downloadable): self
+    {
+        $this->downloadable = $downloadable;
+
+        return $this;
+    }
+
+    public function getRemovable(): ?bool
+    {
+        return $this->removable;
+    }
+
+    public function setRemovable(bool $removable): self
+    {
+        $this->removable = $removable;
+
+        return $this;
+    }
+}

--- a/src/Core/Presentation.php
+++ b/src/Core/Presentation.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace BigBlueButton\Core;
 
+use BigBlueButton\Util\SimpleXMLElementExtended;
+
 abstract class Presentation
 {
     protected ?string $filename = null;
@@ -32,7 +34,7 @@ abstract class Presentation
 
     protected ?bool $removable = null;
 
-    public function addDocumentToXML(\SimpleXMLElement $module): ?\SimpleXMLElement
+    public function addDocumentToXML(SimpleXMLElementExtended $module): ?SimpleXMLElementExtended
     {
         $document = $module->addChild('document');
 
@@ -50,6 +52,8 @@ abstract class Presentation
 
         return $document;
     }
+
+    abstract public function getArrayKey(): string;
 
     public function getFilename(): ?string
     {

--- a/src/Core/UrlPresentation.php
+++ b/src/Core/UrlPresentation.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * BigBlueButton open source conferencing system - https://www.bigbluebutton.org/.
+ *
+ * Copyright (c) 2016-2018 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace BigBlueButton\Core;
+
+class UrlPresentation extends Presentation
+{
+    public function __construct(private readonly string $url)
+    {
+    }
+
+    public function getArrayKey()
+    {
+        return $this->url;
+    }
+
+    public function addDocumentToXML(\SimpleXMLElement $module): ?\SimpleXMLElement
+    {
+        $document = parent::addDocumentToXML($module);
+        $document->addAttribute('url', $this->url);
+
+        if (isset($this->filename)) {
+            $document->addAttribute('filename', $this->filename);
+        }
+
+        return $document;
+    }
+}

--- a/src/Core/UrlPresentation.php
+++ b/src/Core/UrlPresentation.php
@@ -22,18 +22,20 @@ declare(strict_types=1);
 
 namespace BigBlueButton\Core;
 
+use BigBlueButton\Util\SimpleXMLElementExtended;
+
 class UrlPresentation extends Presentation
 {
     public function __construct(private readonly string $url)
     {
     }
 
-    public function getArrayKey()
+    public function getArrayKey(): string
     {
         return $this->url;
     }
 
-    public function addDocumentToXML(\SimpleXMLElement $module): ?\SimpleXMLElement
+    public function addDocumentToXML(SimpleXMLElementExtended $module): ?SimpleXMLElementExtended
     {
         $document = parent::addDocumentToXML($module);
         $document->addAttribute('url', $this->url);

--- a/src/Core/UrlPresentation.php
+++ b/src/Core/UrlPresentation.php
@@ -24,7 +24,7 @@ namespace BigBlueButton\Core;
 
 use BigBlueButton\Util\SimpleXMLElementExtended;
 
-class UrlPresentation extends Presentation
+final class UrlPresentation extends Presentation
 {
     public function __construct(private readonly string $url)
     {

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -248,7 +248,7 @@ class CreateMeetingParameters extends MetaParameters
     protected ?string $clientSettingsOverride = null;
 
     /**
-     * @var array<string,string>
+     * @var array<string,array<string, string|bool|null>>
      */
     private array $presentations = [];
 
@@ -351,13 +351,14 @@ class CreateMeetingParameters extends MetaParameters
         return $this;
     }
 
-    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null): self
+    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, ?bool $downloadable = null, ?bool $removable = null): self
     {
-        if (!$filename) {
-            $this->presentations[$nameOrUrl] = !$content ?: base64_encode($content);
-        } else {
-            $this->presentations[$nameOrUrl] = $filename;
-        }
+        $this->presentations[$nameOrUrl] = [
+            'filename' => $filename,
+            'content' => !$content ?: base64_encode($content),
+            'downloadable' => $downloadable,
+            'removable' => $removable,
+        ];
 
         return $this;
     }
@@ -423,18 +424,27 @@ class CreateMeetingParameters extends MetaParameters
             $module = $xml->addChild('module');
             $module->addAttribute('name', 'presentation');
 
-            foreach ($this->presentations as $nameOrUrl => $content) {
+            foreach ($this->presentations as $nameOrUrl => $data) {
+                $document = $module->addChild('document');
+
                 if (str_starts_with($nameOrUrl, 'http')) {
-                    $presentation = $module->addChild('document');
-                    $presentation->addAttribute('url', $nameOrUrl);
-                    if (\is_string($content)) {
-                        $presentation->addAttribute('filename', $content);
-                    }
+                    $document->addAttribute('url', $nameOrUrl);
                 } else {
-                    $document = $module->addChild('document');
                     $document->addAttribute('name', $nameOrUrl);
                     /* @phpstan-ignore-next-line */
-                    $document[0] = $content;
+                    $document[0] = $data['content'];
+                }
+
+                if (isset($data['filename'])) {
+                    $document->addAttribute('filename', $data['filename']);
+                }
+
+                if (\is_bool($data['downloadable'])) {
+                    $document->addAttribute('downloadable', $data['downloadable'] ? 'true' : 'false');
+                }
+
+                if (\is_bool($data['removable'])) {
+                    $document->addAttribute('removable', $data['removable'] ? 'true' : 'false');
                 }
             }
         }

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -363,7 +363,7 @@ class CreateMeetingParameters extends MetaParameters
             return $this;
         }
 
-        @trigger_error(\sprintf('Calling addPresentation in "%s" without a Presentation object is deprecated and will throw an exception in 7.0.', self::class), \E_USER_DEPRECATED);
+        @trigger_error(\sprintf('Calling addPresentation in "%s" with any parameters other than a single Presentation object is deprecated and will throw an exception in 7.0.', self::class), \E_USER_DEPRECATED);
 
         if ($content) {
             $presentation = new InlinePresentation($content, $nameOrUrlOrPresentation);

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace BigBlueButton\Parameters;
 
+use BigBlueButton\Core\Presentation;
 use BigBlueButton\Enum\Feature;
 use BigBlueButton\Enum\GuestPolicy;
 use BigBlueButton\Enum\MeetingLayout;
@@ -351,14 +352,22 @@ class CreateMeetingParameters extends MetaParameters
         return $this;
     }
 
-    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, ?bool $downloadable = null, ?bool $removable = null, ?bool $current = null): self
+    /**
+     * @return $this
+     */
+    public function addPresentation(string|Presentation $nameOrUrlOrPresentation, ?string $content = null, ?string $filename = null): self
     {
-        $this->presentations[$nameOrUrl] = [
+        if ($nameOrUrlOrPresentation instanceof Presentation) {
+            $this->presentations[$nameOrUrlOrPresentation->getArrayKey()] = $nameOrUrlOrPresentation;
+
+            return $this;
+        }
+
+        @trigger_error(\sprintf('Calling addPresentation without a Presentation object is deprecated and will throw an exception in 7.0.', self::class), \E_USER_DEPRECATED);
+
+        $this->presentations[$nameOrUrlOrPresentation] = [
             'filename' => $filename,
             'content' => !$content ?: base64_encode($content),
-            'downloadable' => $downloadable,
-            'removable' => $removable,
-            'current' => $current,
         ];
 
         return $this;
@@ -426,6 +435,11 @@ class CreateMeetingParameters extends MetaParameters
             $module->addAttribute('name', 'presentation');
 
             foreach ($this->presentations as $nameOrUrl => $data) {
+                if ($data instanceof Presentation) {
+                    $data->addDocumentToXML($module);
+                    continue;
+                }
+
                 $document = $module->addChild('document');
 
                 if (str_starts_with($nameOrUrl, 'http')) {

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -248,9 +248,6 @@ class CreateMeetingParameters extends MetaParameters
     protected ?bool $allowOverrideClientSettingsOnCreateCall = null;
     protected ?string $clientSettingsOverride = null;
 
-    /**
-     * @var array<string,array<string, string|bool|null>>
-     */
     private array $presentations = [];
 
     public function __construct(protected string $meetingID, protected string $name)

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -22,7 +22,9 @@ declare(strict_types=1);
 
 namespace BigBlueButton\Parameters;
 
+use BigBlueButton\Core\InlinePresentation;
 use BigBlueButton\Core\Presentation;
+use BigBlueButton\Core\UrlPresentation;
 use BigBlueButton\Enum\Feature;
 use BigBlueButton\Enum\GuestPolicy;
 use BigBlueButton\Enum\MeetingLayout;
@@ -248,6 +250,7 @@ class CreateMeetingParameters extends MetaParameters
     protected ?bool $allowOverrideClientSettingsOnCreateCall = null;
     protected ?string $clientSettingsOverride = null;
 
+    /** @var array<string,Presentation> */
     private array $presentations = [];
 
     public function __construct(protected string $meetingID, protected string $name)
@@ -360,12 +363,20 @@ class CreateMeetingParameters extends MetaParameters
             return $this;
         }
 
-        @trigger_error(\sprintf('Calling addPresentation without a Presentation object is deprecated and will throw an exception in 7.0.', self::class), \E_USER_DEPRECATED);
+        @trigger_error(\sprintf('Calling addPresentation in "%s" without a Presentation object is deprecated and will throw an exception in 7.0.', self::class), \E_USER_DEPRECATED);
 
-        $this->presentations[$nameOrUrlOrPresentation] = [
-            'filename' => $filename,
-            'content' => !$content ?: base64_encode($content),
-        ];
+        if ($content) {
+            $presentation = new InlinePresentation($content, $nameOrUrlOrPresentation);
+            $this->presentations[$presentation->getArrayKey()] = $presentation;
+        } else {
+            $presentation = new UrlPresentation($nameOrUrlOrPresentation);
+
+            if ($filename != null) {
+                $presentation->setFilename($filename);
+            }
+
+            $this->presentations[$presentation->getArrayKey()] = $presentation;
+        }
 
         return $this;
     }
@@ -390,7 +401,7 @@ class CreateMeetingParameters extends MetaParameters
         return $this;
     }
 
-    /** @return array<string,string> */
+    /** @return array<string,Presentation> */
     public function getPresentations(): array
     {
         return $this->presentations;
@@ -431,36 +442,9 @@ class CreateMeetingParameters extends MetaParameters
             $module = $xml->addChild('module');
             $module->addAttribute('name', 'presentation');
 
-            foreach ($this->presentations as $nameOrUrl => $data) {
+            foreach ($this->presentations as $data) {
                 if ($data instanceof Presentation) {
                     $data->addDocumentToXML($module);
-                    continue;
-                }
-
-                $document = $module->addChild('document');
-
-                if (str_starts_with($nameOrUrl, 'http')) {
-                    $document->addAttribute('url', $nameOrUrl);
-                } else {
-                    $document->addAttribute('name', $nameOrUrl);
-                    /* @phpstan-ignore-next-line */
-                    $document[0] = $data['content'];
-                }
-
-                if (isset($data['filename'])) {
-                    $document->addAttribute('filename', $data['filename']);
-                }
-
-                if (\is_bool($data['downloadable'])) {
-                    $document->addAttribute('downloadable', $data['downloadable'] ? 'true' : 'false');
-                }
-
-                if (\is_bool($data['removable'])) {
-                    $document->addAttribute('removable', $data['removable'] ? 'true' : 'false');
-                }
-
-                if (\is_bool($data['current'])) {
-                    $document->addAttribute('current', $data['current'] ? 'true' : 'false');
                 }
             }
         }

--- a/src/Parameters/CreateMeetingParameters.php
+++ b/src/Parameters/CreateMeetingParameters.php
@@ -351,13 +351,14 @@ class CreateMeetingParameters extends MetaParameters
         return $this;
     }
 
-    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, ?bool $downloadable = null, ?bool $removable = null): self
+    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, ?bool $downloadable = null, ?bool $removable = null, ?bool $current = null): self
     {
         $this->presentations[$nameOrUrl] = [
             'filename' => $filename,
             'content' => !$content ?: base64_encode($content),
             'downloadable' => $downloadable,
             'removable' => $removable,
+            'current' => $current,
         ];
 
         return $this;
@@ -445,6 +446,10 @@ class CreateMeetingParameters extends MetaParameters
 
                 if (\is_bool($data['removable'])) {
                     $document->addAttribute('removable', $data['removable'] ? 'true' : 'false');
+                }
+
+                if (\is_bool($data['current'])) {
+                    $document->addAttribute('current', $data['current'] ? 'true' : 'false');
                 }
             }
         }

--- a/src/Parameters/InsertDocumentParameters.php
+++ b/src/Parameters/InsertDocumentParameters.php
@@ -34,10 +34,11 @@ final class InsertDocumentParameters extends MetaParameters
     {
     }
 
-    public function addPresentation(string $url, string $filename, ?bool $downloadable = null, ?bool $removable = null): self
+    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, ?bool $downloadable = null, ?bool $removable = null): self
     {
-        $this->presentations[$url] = [
+        $this->presentations[$nameOrUrl] = [
             'filename' => $filename,
+            'content' => !$content ?: base64_encode($content),
             'downloadable' => $downloadable,
             'removable' => $removable,
         ];
@@ -61,17 +62,27 @@ final class InsertDocumentParameters extends MetaParameters
             $module = $xml->addChild('module');
             $module->addAttribute('name', 'presentation');
 
-            foreach ($this->presentations as $url => $content) {
-                $presentation = $module->addChild('document');
-                $presentation->addAttribute('url', $url);
-                $presentation->addAttribute('filename', $content['filename']);
+            foreach ($this->presentations as $nameOrUrl => $data) {
+                $document = $module->addChild('document');
 
-                if (\is_bool($content['downloadable'])) {
-                    $presentation->addAttribute('downloadable', $content['downloadable'] ? 'true' : 'false');
+                if (str_starts_with($nameOrUrl, 'http')) {
+                    $document->addAttribute('url', $nameOrUrl);
+                } else {
+                    $document->addAttribute('name', $nameOrUrl);
+                    /* @phpstan-ignore-next-line */
+                    $document[0] = $data['content'];
                 }
 
-                if (\is_bool($content['removable'])) {
-                    $presentation->addAttribute('removable', $content['removable'] ? 'true' : 'false');
+                if (isset($data['filename'])) {
+                    $document->addAttribute('filename', $data['filename']);
+                }
+
+                if (\is_bool($data['downloadable'])) {
+                    $document->addAttribute('downloadable', $data['downloadable'] ? 'true' : 'false');
+                }
+
+                if (\is_bool($data['removable'])) {
+                    $document->addAttribute('removable', $data['removable'] ? 'true' : 'false');
                 }
             }
             $result = $xml->asXML();

--- a/src/Parameters/InsertDocumentParameters.php
+++ b/src/Parameters/InsertDocumentParameters.php
@@ -29,7 +29,6 @@ use BigBlueButton\Core\Presentation;
  */
 final class InsertDocumentParameters extends MetaParameters
 {
-    /** @var array<string,array{filename: string, downloadable: bool|null, removable: bool|null}> */
     private array $presentations = [];
 
     public function __construct(protected string $meetingID)

--- a/src/Parameters/InsertDocumentParameters.php
+++ b/src/Parameters/InsertDocumentParameters.php
@@ -60,6 +60,8 @@ final class InsertDocumentParameters extends MetaParameters
             $presentation->setRemovable($removable);
         }
 
+        $this->presentations[$presentation->getArrayKey()] = $presentation;
+
         return $this;
     }
 

--- a/src/Parameters/InsertDocumentParameters.php
+++ b/src/Parameters/InsertDocumentParameters.php
@@ -34,13 +34,14 @@ final class InsertDocumentParameters extends MetaParameters
     {
     }
 
-    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, ?bool $downloadable = null, ?bool $removable = null): self
+    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, ?bool $downloadable = null, ?bool $removable = null, ?bool $current = null): self
     {
         $this->presentations[$nameOrUrl] = [
             'filename' => $filename,
             'content' => !$content ?: base64_encode($content),
             'downloadable' => $downloadable,
             'removable' => $removable,
+            'current' => $current,
         ];
 
         return $this;
@@ -83,6 +84,10 @@ final class InsertDocumentParameters extends MetaParameters
 
                 if (\is_bool($data['removable'])) {
                     $document->addAttribute('removable', $data['removable'] ? 'true' : 'false');
+                }
+
+                if (\is_bool($data['current'])) {
+                    $document->addAttribute('current', $data['current'] ? 'true' : 'false');
                 }
             }
             $result = $xml->asXML();

--- a/src/Parameters/InsertDocumentParameters.php
+++ b/src/Parameters/InsertDocumentParameters.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace BigBlueButton\Parameters;
 
+use BigBlueButton\Core\Presentation;
+
 /**
  * @method string getMeetingID()
  * @method $this  setMeetingID(string $id)
@@ -34,14 +36,20 @@ final class InsertDocumentParameters extends MetaParameters
     {
     }
 
-    public function addPresentation(string $nameOrUrl, ?string $content = null, ?string $filename = null, ?bool $downloadable = null, ?bool $removable = null, ?bool $current = null): self
+    public function addPresentation(string|Presentation $urlOrPresentation, ?string $filename = null, ?bool $downloadable = null, ?bool $removable = null): self
     {
-        $this->presentations[$nameOrUrl] = [
+        if ($urlOrPresentation instanceof Presentation) {
+            $this->presentations[$urlOrPresentation->getArrayKey()] = $urlOrPresentation;
+
+            return $this;
+        }
+
+        @trigger_error(\sprintf('Calling addPresentation without a Presentation object is deprecated and will throw an exception in 7.0.', self::class), \E_USER_DEPRECATED);
+
+        $this->presentations[$urlOrPresentation] = [
             'filename' => $filename,
-            'content' => !$content ?: base64_encode($content),
             'downloadable' => $downloadable,
             'removable' => $removable,
-            'current' => $current,
         ];
 
         return $this;
@@ -63,31 +71,22 @@ final class InsertDocumentParameters extends MetaParameters
             $module = $xml->addChild('module');
             $module->addAttribute('name', 'presentation');
 
-            foreach ($this->presentations as $nameOrUrl => $data) {
-                $document = $module->addChild('document');
-
-                if (str_starts_with($nameOrUrl, 'http')) {
-                    $document->addAttribute('url', $nameOrUrl);
-                } else {
-                    $document->addAttribute('name', $nameOrUrl);
-                    /* @phpstan-ignore-next-line */
-                    $document[0] = $data['content'];
+            foreach ($this->presentations as $url => $content) {
+                if ($content instanceof Presentation) {
+                    $content->addDocumentToXML($module);
+                    continue;
                 }
 
-                if (isset($data['filename'])) {
-                    $document->addAttribute('filename', $data['filename']);
+                $presentation = $module->addChild('document');
+                $presentation->addAttribute('url', $url);
+                $presentation->addAttribute('filename', $content['filename']);
+
+                if (\is_bool($content['downloadable'])) {
+                    $presentation->addAttribute('downloadable', $content['downloadable'] ? 'true' : 'false');
                 }
 
-                if (\is_bool($data['downloadable'])) {
-                    $document->addAttribute('downloadable', $data['downloadable'] ? 'true' : 'false');
-                }
-
-                if (\is_bool($data['removable'])) {
-                    $document->addAttribute('removable', $data['removable'] ? 'true' : 'false');
-                }
-
-                if (\is_bool($data['current'])) {
-                    $document->addAttribute('current', $data['current'] ? 'true' : 'false');
+                if (\is_bool($content['removable'])) {
+                    $presentation->addAttribute('removable', $content['removable'] ? 'true' : 'false');
                 }
             }
             $result = $xml->asXML();

--- a/src/Parameters/InsertDocumentParameters.php
+++ b/src/Parameters/InsertDocumentParameters.php
@@ -46,7 +46,7 @@ final class InsertDocumentParameters extends MetaParameters
             return $this;
         }
 
-        @trigger_error(\sprintf('Calling addPresentation in "%s" without a Presentation object is deprecated and will throw an exception in 7.0.', self::class), \E_USER_DEPRECATED);
+        @trigger_error(\sprintf('Calling addPresentation in "%s" with any parameters other than a single Presentation object is deprecated and will throw an exception in 7.0.', self::class), \E_USER_DEPRECATED);
 
         $presentation = new UrlPresentation($urlOrPresentation);
 

--- a/src/Parameters/InsertDocumentParameters.php
+++ b/src/Parameters/InsertDocumentParameters.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 namespace BigBlueButton\Parameters;
 
 use BigBlueButton\Core\Presentation;
+use BigBlueButton\Core\UrlPresentation;
+use BigBlueButton\Util\SimpleXMLElementExtended;
 
 /**
  * @method string getMeetingID()
@@ -29,6 +31,7 @@ use BigBlueButton\Core\Presentation;
  */
 final class InsertDocumentParameters extends MetaParameters
 {
+    /** @var array<string,Presentation> */
     private array $presentations = [];
 
     public function __construct(protected string $meetingID)
@@ -43,13 +46,19 @@ final class InsertDocumentParameters extends MetaParameters
             return $this;
         }
 
-        @trigger_error(\sprintf('Calling addPresentation without a Presentation object is deprecated and will throw an exception in 7.0.', self::class), \E_USER_DEPRECATED);
+        @trigger_error(\sprintf('Calling addPresentation in "%s" without a Presentation object is deprecated and will throw an exception in 7.0.', self::class), \E_USER_DEPRECATED);
 
-        $this->presentations[$urlOrPresentation] = [
-            'filename' => $filename,
-            'downloadable' => $downloadable,
-            'removable' => $removable,
-        ];
+        $presentation = new UrlPresentation($urlOrPresentation);
+
+        if ($filename !== null) {
+            $presentation->setFilename($filename);
+        }
+        if ($downloadable !== null) {
+            $presentation->setDownloadable($downloadable);
+        }
+        if ($removable !== null) {
+            $presentation->setRemovable($removable);
+        }
 
         return $this;
     }
@@ -66,26 +75,13 @@ final class InsertDocumentParameters extends MetaParameters
         $result = '';
 
         if (!empty($this->presentations)) {
-            $xml = new \SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><modules/>');
+            $xml = new SimpleXMLElementExtended('<?xml version="1.0" encoding="UTF-8"?><modules/>');
             $module = $xml->addChild('module');
             $module->addAttribute('name', 'presentation');
 
-            foreach ($this->presentations as $url => $content) {
+            foreach ($this->presentations as $content) {
                 if ($content instanceof Presentation) {
                     $content->addDocumentToXML($module);
-                    continue;
-                }
-
-                $presentation = $module->addChild('document');
-                $presentation->addAttribute('url', $url);
-                $presentation->addAttribute('filename', $content['filename']);
-
-                if (\is_bool($content['downloadable'])) {
-                    $presentation->addAttribute('downloadable', $content['downloadable'] ? 'true' : 'false');
-                }
-
-                if (\is_bool($content['removable'])) {
-                    $presentation->addAttribute('removable', $content['removable'] ? 'true' : 'false');
                 }
             }
             $result = $xml->asXML();


### PR DESCRIPTION
- Add support for `downloadable`, `removable` and `current` attribute for pre-uploaded slides in create api call
- Add support for embedded slides in insert document api call

Based on https://github.com/littleredbutton/bigbluebutton-api-php/pull/228, extended to to more complete PR and change

Official docs: https://github.com/bigbluebutton/bigbluebutton/issues/24657 updated