### PR TITLE
Fix invalid hook type

### DIFF
--- a/src/Core/Hook.php
+++ b/src/Core/Hook.php
@@ -27,7 +27,7 @@ namespace BigBlueButton\Core;
  */
 class Hook
 {
-    private readonly int $hookId;
+    private readonly string $hookId;
 
     private readonly string $meetingId;
 
@@ -39,14 +39,14 @@ class Hook
 
     public function __construct(protected \SimpleXMLElement $rawXml)
     {
-        $this->hookId = (int) $this->rawXml->hookID->__toString();
+        $this->hookId = $this->rawXml->hookID->__toString();
         $this->callbackUrl = $this->rawXml->callbackURL->__toString();
         $this->meetingId = $this->rawXml->meetingID->__toString();
         $this->permanentHook = $this->rawXml->permanentHook->__toString() === 'true';
         $this->rawData = $this->rawXml->rawData->__toString() === 'true';
     }
 
-    public function getHookId(): int
+    public function getHookId(): string
     {
         return $this->hookId;
     }

--- a/src/Responses/HooksCreateResponse.php
+++ b/src/Responses/HooksCreateResponse.php
@@ -27,9 +27,9 @@ namespace BigBlueButton\Responses;
  */
 class HooksCreateResponse extends BaseResponse
 {
-    public function getHookId(): int
+    public function getHookId(): string
     {
-        return (int) $this->rawXml->hookID->__toString();
+        return $this->rawXml->hookID->__toString();
     }
 
     public function isPermanentHook(): bool

--- a/tests/fixtures/hooks_create.xml
+++ b/tests/fixtures/hooks_create.xml
@@ -1,6 +1,6 @@
 <response>
     <returncode>SUCCESS</returncode>
-    <hookID>1</hookID>
+    <hookID>12345678-1234-5678-1234-567812345678</hookID>
     <permanentHook>false</permanentHook>
     <rawData>false</rawData>
 </response>

--- a/tests/fixtures/hooks_create_existing.xml
+++ b/tests/fixtures/hooks_create_existing.xml
@@ -1,6 +1,6 @@
 <response>
     <returncode>SUCCESS</returncode>
-    <hookID>1</hookID>
+    <hookID>12345678-1234-5678-1234-567812345678</hookID>
     <messageKey>duplicateWarning</messageKey>
     <message>There is already a hook for this callback URL.</message>
 </response>

--- a/tests/fixtures/hooks_list.xml
+++ b/tests/fixtures/hooks_list.xml
@@ -2,14 +2,14 @@
     <returncode>SUCCESS</returncode>
     <hooks>
         <hook>
-            <hookID>1</hookID>
+            <hookID>12345678-1234-5678-1234-567812345678</hookID>
             <callbackURL><![CDATA[http://postcatcher.in/catchers/abcdefghijk]]></callbackURL>
             <meetingID><![CDATA[my-meeting]]></meetingID>
             <permanentHook>false</permanentHook>
             <rawData>false</rawData>
         </hook>
         <hook>
-            <hookID>2</hookID>
+            <hookID>23456789-1234-5678-1234-567812345678</hookID>
             <callbackURL><![CDATA[http://postcatcher.in/catchers/1234567890]]></callbackURL>
             <permanentHook>false</permanentHook>
             <rawData>false</rawData>

--- a/tests/unit/BigBlueButtonTest.php
+++ b/tests/unit/BigBlueButtonTest.php
@@ -687,7 +687,7 @@ final class BigBlueButtonTest extends TestCase
 
         $xml = '<response>
           <returncode>SUCCESS</returncode>
-          <hookID>1</hookID>
+          <hookID>12345678-1234-5678-1234-567812345678</hookID>
           <permanentHook>false</permanentHook>
           <rawData>false</rawData>
         </response>';
@@ -697,7 +697,7 @@ final class BigBlueButtonTest extends TestCase
         $response = $this->bbb->hooksCreate($params);
 
         $this->assertTrue($response->success());
-        $this->assertSame(1, $response->getHookId());
+        $this->assertSame('12345678-1234-5678-1234-567812345678', $response->getHookId());
         $this->assertFalse($response->isPermanentHook());
         $this->assertFalse($response->hasRawData());
     }
@@ -710,14 +710,14 @@ final class BigBlueButtonTest extends TestCase
           <returncode>SUCCESS</returncode>
           <hooks>
             <hook>
-              <hookID>1</hookID>
+              <hookID>12345678-1234-5678-1234-567812345678</hookID>
               <callbackURL><![CDATA[http://postcatcher.in/catchers/abcdefghijk]]></callbackURL>
               <meetingID><![CDATA[my-meeting]]></meetingID>
               <permanentHook>false</permanentHook>
               <rawData>false</rawData>
             </hook>
             <hook>
-              <hookID>2</hookID>
+              <hookID>23456789-1234-5678-1234-567812345678</hookID>
               <callbackURL><![CDATA[http://postcatcher.in/catchers/1234567890]]></callbackURL>
               <permanentHook>false</permanentHook>
               <rawData>false</rawData>
@@ -734,7 +734,7 @@ final class BigBlueButtonTest extends TestCase
 
         // Hook for a single meeting
         $meetingHook = $response->getHooks()[0];
-        $this->assertSame(1, $meetingHook->getHookId());
+        $this->assertSame('12345678-1234-5678-1234-567812345678', $meetingHook->getHookId());
         $this->assertSame('http://postcatcher.in/catchers/abcdefghijk', $meetingHook->getCallbackURL());
         $this->assertSame('my-meeting', $meetingHook->getMeetingID());
         $this->assertFalse($meetingHook->isPermanentHook());
@@ -742,7 +742,7 @@ final class BigBlueButtonTest extends TestCase
 
         // Global hook
         $globalHook = $response->getHooks()[1];
-        $this->assertSame(2, $globalHook->getHookId());
+        $this->assertSame('23456789-1234-5678-1234-567812345678', $globalHook->getHookId());
         $this->assertSame('http://postcatcher.in/catchers/1234567890', $globalHook->getCallbackURL());
         $this->assertFalse($globalHook->isPermanentHook());
         $this->assertFalse($globalHook->hasRawData());

--- a/tests/unit/Parameters/HooksDestroyParametersTest.php
+++ b/tests/unit/Parameters/HooksDestroyParametersTest.php
@@ -29,7 +29,7 @@ final class HooksDestroyParametersTest extends TestCase
 {
     public function testHooksDestroyParameters(): void
     {
-        $hooksCreateParameters = new HooksDestroyParameters((string) $hookId = $this->faker->numberBetween(1, 50));
+        $hooksCreateParameters = new HooksDestroyParameters($hookId = $this->faker->uuid());
 
         $this->assertEquals($hookId, $hooksCreateParameters->getHookID());
     }

--- a/tests/unit/Responses/HooksCreateResponseTest.php
+++ b/tests/unit/Responses/HooksCreateResponseTest.php
@@ -41,7 +41,7 @@ final class HooksCreateResponseTest extends TestCase
     public function testHooksCreateResponseContent(): void
     {
         $this->assertEquals('SUCCESS', $this->createResponse->getReturnCode());
-        $this->assertEquals(1, $this->createResponse->getHookId());
+        $this->assertEquals('12345678-1234-5678-1234-567812345678', $this->createResponse->getHookId());
         $this->assertFalse($this->createResponse->isPermanentHook());
         $this->assertFalse($this->createResponse->hasRawData());
     }
@@ -49,7 +49,7 @@ final class HooksCreateResponseTest extends TestCase
     public function testHooksCreateResponseTypes(): void
     {
         $this->assertEachGetterValueIsString($this->createResponse, ['getReturnCode']);
-        $this->assertEachGetterValueIsInteger($this->createResponse, ['getHookId']);
+        $this->assertEachGetterValueIsString($this->createResponse, ['getHookId']);
         $this->assertEachGetterValueIsBoolean($this->createResponse, ['isPermanentHook', 'hasRawData']);
     }
 }

--- a/tests/unit/Responses/HooksListResponseTest.php
+++ b/tests/unit/Responses/HooksListResponseTest.php
@@ -47,7 +47,7 @@ final class HooksListResponseTest extends TestCase
 
         $this->assertEquals('my-meeting', $aHook->getMeetingId());
         $this->assertEquals('http://postcatcher.in/catchers/abcdefghijk', $aHook->getCallbackUrl());
-        $this->assertEquals(1, $aHook->getHookId());
+        $this->assertEquals('12345678-1234-5678-1234-567812345678', $aHook->getHookId());
         $this->assertFalse($aHook->isPermanentHook());
         $this->assertFalse($aHook->hasRawData());
     }
@@ -59,7 +59,7 @@ final class HooksListResponseTest extends TestCase
         $aHook = $this->listResponse->getHooks()[0];
 
         $this->assertEachGetterValueIsString($aHook, ['getCallbackUrl', 'getMeetingId']);
-        $this->assertEachGetterValueIsInteger($aHook, ['getHookId']);
+        $this->assertEachGetterValueIsString($aHook, ['getHookId']);
         $this->assertEachGetterValueIsBoolean($aHook, ['hasRawData', 'isPermanentHook']);
     }
 }


### PR DESCRIPTION
# Fixes #233

Changed in BBB 3.0 from int to string
Our currently implementation was already using string for `HooksDestroyParameters` , but the return types where using int

Should be part of the next major version. 